### PR TITLE
Change button from "replies" to "responses"

### DIFF
--- a/__test__/AssignmentSummary.test.js
+++ b/__test__/AssignmentSummary.test.js
@@ -189,7 +189,7 @@ describe('contacts filters', () => {
     expect(sendFirstTexts.contactsFilter).toBe('text')
 
     const sendReplies = mockRender.mock.calls[1][0]
-    expect(sendReplies.title).toBe('Send replies')
+    expect(sendReplies.title).toBe('Send responses')
     expect(sendReplies.contactsFilter).toBe('reply')
 
     const sendLater = mockRender.mock.calls[2][0]

--- a/src/components/AssignmentSummary.jsx
+++ b/src/components/AssignmentSummary.jsx
@@ -119,7 +119,7 @@ export class AssignmentSummary extends Component {
             })}
             {(window.NOT_IN_USA && window.ALLOW_SEND_ALL) ? '' : this.renderBadgedButton({
               assignment,
-              title: 'Send replies',
+              title: 'Send responses',
               count: unrepliedCount,
               primary: false,
               disabled: false,

--- a/src/containers/AssignmentTexterContact.jsx
+++ b/src/containers/AssignmentTexterContact.jsx
@@ -595,7 +595,7 @@ export class AssignmentTexterContact extends React.Component {
     } else if (messageStatus === 'needsResponse') {
       button = (<RaisedButton
         onTouchTap={this.handleClickCloseContactButton}
-        label='Skip Reply'
+        label='Skip Response'
       />)
     }
 


### PR DESCRIPTION
Per suggestion by Dinah -- "replies" are from contacts to texters, "responses" are sent by texters to contacts.