### PR TITLE
[WIP] Extension Settings Panel

### DIFF
--- a/src/api/organization.js
+++ b/src/api/organization.js
@@ -50,6 +50,7 @@ export const schema = gql`
     allowedMessageHandlers: [String]
     allowedActionHandlers: [String]
     allowedContactLoaders: [String]
+    handlerDisplayInformation: String
   }
 
   input ExtensionSettingsInput {
@@ -59,6 +60,7 @@ export const schema = gql`
     allowedMessageHandlers: [String]
     allowedActionHandlers: [String]
     allowedContactLoaders: [String]
+    handlerDisplayInformation: String
   }
 
   type Organization {

--- a/src/api/organization.js
+++ b/src/api/organization.js
@@ -36,6 +36,7 @@ export const schema = gql`
   type OrgSettings {
     messageHandlers: [String]
     actionHandlers: [String]
+    contactLoaders: [String]
     featuresJSON: String
     unsetFeatures: [String]
   }
@@ -43,6 +44,7 @@ export const schema = gql`
   input OrgSettingsInput {
     messageHandlers: [String]
     actionHandlers: [String]
+    contactLoaders: [String]
     featuresJSON: String
     unsetFeatures: [String]
   }

--- a/src/api/organization.js
+++ b/src/api/organization.js
@@ -33,20 +33,32 @@ export const schema = gql`
     label: String!
   }
 
-  type OrgSettings {
-    messageHandlers: [String]
-    actionHandlers: [String]
-    contactLoaders: [String]
+  type DefaultSettings {
     featuresJSON: String
     unsetFeatures: [String]
   }
 
-  input OrgSettingsInput {
-    messageHandlers: [String]
-    actionHandlers: [String]
-    contactLoaders: [String]
+  input DefaultSettingsInput {
     featuresJSON: String
     unsetFeatures: [String]
+  }
+
+  type ExtensionSettings {
+    savedMessageHandlers: [String]
+    savedActionHandlers: [String]
+    savedContactLoaders: [String]
+    allowedMessageHandlers: [String]
+    allowedActionHandlers: [String]
+    allowedContactLoaders: [String]
+  }
+
+  input ExtensionSettingsInput {
+    savedMessageHandlers: [String]
+    savedActionHandlers: [String]
+    savedContactLoaders: [String]
+    allowedMessageHandlers: [String]
+    allowedActionHandlers: [String]
+    allowedContactLoaders: [String]
   }
 
   type Organization {
@@ -63,7 +75,8 @@ export const schema = gql`
     optOuts: [OptOut]
     allowSendAll: Boolean
     availableActions: [Action]
-    settings: OrgSettings
+    defaultSettings: DefaultSettings
+    extensionSettings: ExtensionSettings
     optOutMessage: String
     textingHoursEnforced: Boolean
     textingHoursStart: Int

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -92,7 +92,8 @@ const rootSchema = gql`
 
   input OrganizationInput {
     texterUIConfig: TexterUIConfigInput
-    settings: OrgSettingsInput
+    defaultSettings: DefaultSettingsInput
+    extensionSettings: ExtensionSettingsInput
   }
 
   input MessageInput {

--- a/src/components/ExtensionSettings.jsx
+++ b/src/components/ExtensionSettings.jsx
@@ -1,20 +1,10 @@
 import type from "prop-types";
 import React from "react";
-import orderBy from "lodash/orderBy";
-import Slider from "./Slider";
-import Divider from "material-ui/Divider";
-import AutoComplete from "material-ui/AutoComplete";
-import IconButton from "material-ui/IconButton";
-import RaisedButton from "material-ui/RaisedButton";
 import GSForm from "../components/forms/GSForm";
 import yup from "yup";
 import Form from "react-formal";
-import OrganizationJoinLink from "./OrganizationJoinLink";
-import CampaignFormSectionHeading from "./CampaignFormSectionHeading";
 import { StyleSheet, css } from "aphrodite";
-import theme from "../styles/theme";
 import Toggle from "material-ui/Toggle";
-import DeleteIcon from "material-ui/svg-icons/action/delete";
 import { dataTest } from "../lib/attributes";
 import { dataSourceItem } from "./utils";
 
@@ -24,44 +14,33 @@ const toggled = (name, isToggled) => {
   this.props.onChange(formValues);
 };
 
-/*
-export default class Integration = (props) => {
-  return  
-    <Form.Field
-      label={props.label}
-      name={props.name}
-      type={Toggle}
-      defaultToggled={true}
-      onToggle={async (_, isToggled) => {
-        this.toggled(name, isToggled);
-      }}
-    />
-}
-*/
+const IntegrationCategory = props => {
+  return;
+  <Form.Field
+    label={props.label}
+    name={props.name}
+    type={Toggle}
+    defaultToggled={true}
+    onToggle={async (_, isToggled) => {
+      this.toggled(name, isToggled);
+    }}
+  />;
+};
 
 const integrationCategories = {
   ACTION_HANDLERS: {
     schema: yup.string(),
     component: props => {
       // toggles on/off for each handler, needs a description of each
-      /* 
       return (
-        {props.actionHandlers && (
-          <div>Bob's Actions</>
-          {props.actionHandlers.map(ah => (
-            <Integration>
-              label = ah
-              name = ah
-              description = "ready set action handler"
-              fullWidth
-            </>
-            )
-          )}
-        }
-      )
-      */
-      return (
-        <Form.Field label="Action Handlers" name="ACTION_HANDLERS" fullWidth />
+        props.ACTION_HANDLERS && (
+          <div>
+            <div>Bob's Actions</div>
+            {props.actionHandlers.map(ah => (
+              <IntegrationCategory label={ah} name={ah} />
+            ))}
+          </div>
+        )
       );
     }
   },
@@ -74,6 +53,7 @@ const integrationCategories = {
           label="Message Handlers (comma-separated)"
           name="MESSAGE_HANDLERS"
           fullWidth
+          key={2}
         />
       );
     }
@@ -83,41 +63,43 @@ const integrationCategories = {
     component: props => {
       // toggles on/off for each handler, needs a description of each
       return (
-        <Form.Field label="Contact Loaders" name="CONTACT_LOADERS" fullWidth />
+        <Form.Field
+          label="Contact Loaders"
+          name="CONTACT_LOADERS"
+          fullWidth
+          key={3}
+        />
       );
     }
   }
 };
 
-export default class OrganizationFeatureSettings extends React.Component {
+export default class ExtensionSettings extends React.Component {
   constructor(props) {
     super(props);
     const { formValues } = this.props;
     const settingsData =
-      (formValues.settings.featuresJSON &&
-        JSON.parse(formValues.settings.featuresJSON)) ||
-      {};
-    this.state = { ...settingsData, unsetFeatures: [] };
+      (formValues.extensionSettings && formValues.extensionSettings) || {};
+    this.state = { ...settingsData };
   }
 
   onChange = formValues => {
     console.log("onChange state", this.state);
     this.setState(formValues, () => {
       this.props.onChange({
-        settings: {
-          featuresJSON: JSON.stringify(this.state),
-          unsetFeatures: this.state.unsetFeatures
+        extensionSettings: {
+          savedMesssageHandlers: JSON.stringify(this.state.MESSAGE_HANDLERS),
+          savedActionHandlers: JSON.stringify(this.state.ACTION_HANDLERS),
+          savedContactLoaders: JSON.stringify(this.state.CONTACT_LOADERS)
         }
       });
     });
   };
 
   render() {
-    // message handlers add/remove
-    // action handlers: add/remove
-    // features and unsetFeatures list
     const schemaObject = {};
     const adminItems = Object.keys(integrationCategories).map(f => {
+      schemaObject[f] = integrationCategories[f].schema;
       schemaObject[f] = integrationCategories[f].schema;
       return integrationCategories[f].component({
         ...this.props,
@@ -147,7 +129,7 @@ export default class OrganizationFeatureSettings extends React.Component {
   }
 }
 
-OrganizationFeatureSettings.propTypes = {
+ExtensionSettings.propTypes = {
   formValues: type.object,
   organization: type.object,
   onChange: type.func,

--- a/src/components/ExtensionSettings.jsx
+++ b/src/components/ExtensionSettings.jsx
@@ -18,50 +18,55 @@ import DeleteIcon from "material-ui/svg-icons/action/delete";
 import { dataTest } from "../lib/attributes";
 import { dataSourceItem } from "./utils";
 
-const configurableFields = {
+const toggled = (name, isToggled) => {
+  const formValues = cloneDeep(this.props.formValues);
+  formValues[name] = isToggled;
+  this.props.onChange(formValues);
+};
+
+/*
+export default class Integration = (props) => {
+  return  
+    <Form.Field
+      label={props.label}
+      name={props.name}
+      type={Toggle}
+      defaultToggled={true}
+      onToggle={async (_, isToggled) => {
+        this.toggled(name, isToggled);
+      }}
+    />
+}
+*/
+
+const integrationCategories = {
   ACTION_HANDLERS: {
     schema: yup.string(),
-    ready: true,
     component: props => {
       // toggles on/off for each handler, needs a description of each
+      /* 
       return (
-        <Form.Field
-          label="Action Handlers (comma-separated)"
-          name="ACTION_HANDLERS"
-          fullWidth
-        />
+        {props.actionHandlers && (
+          <div>Bob's Actions</>
+          {props.actionHandlers.map(ah => (
+            <Integration>
+              label = ah
+              name = ah
+              description = "ready set action handler"
+              fullWidth
+            </>
+            )
+          )}
+        }
+      )
+      */
+      return (
+        <Form.Field label="Action Handlers" name="ACTION_HANDLERS" fullWidth />
       );
-    }
-  },
-  ALLOW_SEND_ALL_ENABLED: {
-    schema: yup.boolean(),
-    component: props => {
-      // toggle ? with important legal text!!
-      return <div></div>;
-    }
-  },
-  DEFAULT_BATCHSIZE: {
-    schema: yup.number().integer(),
-    component: props => {
-      return <div></div>;
-    }
-  },
-  MAX_CONTACTS_PER_TEXTER: {
-    schema: yup.number().integer(),
-    component: props => {
-      // allow empty (set empty for null)
-      return <div></div>;
-    }
-  },
-  MAX_MESSAGE_LENGTH: {
-    schema: yup.number().integer(),
-    component: props => {
-      return <div></div>;
     }
   },
   MESSAGE_HANDLERS: {
     schema: yup.string(),
-    ready: true,
     component: props => {
       // toggles on/off for each handler, needs a description of each
       return (
@@ -73,11 +78,13 @@ const configurableFields = {
       );
     }
   },
-  opt_out_message: {
+  CONTACT_LOADERS: {
     schema: yup.string(),
     component: props => {
-      // default to props.organization.optOutMessage
-      return <div></div>;
+      // toggles on/off for each handler, needs a description of each
+      return (
+        <Form.Field label="Contact Loaders" name="CONTACT_LOADERS" fullWidth />
+      );
     }
   }
 };
@@ -94,18 +101,8 @@ export default class OrganizationFeatureSettings extends React.Component {
   }
 
   onChange = formValues => {
+    console.log("onChange state", this.state);
     this.setState(formValues, () => {
-      this.props.onChange({
-        settings: {
-          featuresJSON: JSON.stringify(this.state),
-          unsetFeatures: this.state.unsetFeatures
-        }
-      });
-    });
-  };
-
-  toggleChange = (key, value) => {
-    this.setState({ [key]: value }, newData => {
       this.props.onChange({
         settings: {
           featuresJSON: JSON.stringify(this.state),
@@ -120,12 +117,15 @@ export default class OrganizationFeatureSettings extends React.Component {
     // action handlers: add/remove
     // features and unsetFeatures list
     const schemaObject = {};
-    const adminItems = Object.keys(configurableFields)
-      .filter(f => configurableFields[f].ready)
-      .map(f => {
-        schemaObject[f] = configurableFields[f].schema;
-        return configurableFields[f].component({ ...this.props, parent: this });
+    const adminItems = Object.keys(integrationCategories).map(f => {
+      schemaObject[f] = integrationCategories[f].schema;
+      return integrationCategories[f].component({
+        ...this.props,
+        parent: this
       });
+    });
+    console.log("currentstate: ", this.state);
+    console.log("current props: ", this.props);
     return (
       <div>
         <GSForm
@@ -139,7 +139,7 @@ export default class OrganizationFeatureSettings extends React.Component {
             onClick={this.props.onSubmit}
             label={this.props.saveLabel}
             disabled={this.props.saveDisabled}
-            {...dataTest("submitOrganizationFeatureSettings")}
+            {...dataTest("submitExtensionSettings")}
           />
         </GSForm>
       </div>

--- a/src/components/OrganizationFeatureSettings.jsx
+++ b/src/components/OrganizationFeatureSettings.jsx
@@ -19,20 +19,6 @@ import { dataTest } from "../lib/attributes";
 import { dataSourceItem } from "./utils";
 
 const configurableFields = {
-  ACTION_HANDLERS: {
-    schema: yup.string(),
-    ready: true,
-    component: props => {
-      // toggles on/off for each handler, needs a description of each
-      return (
-        <Form.Field
-          label="Action Handlers (comma-separated)"
-          name="ACTION_HANDLERS"
-          fullWidth
-        />
-      );
-    }
-  },
   ALLOW_SEND_ALL_ENABLED: {
     schema: yup.boolean(),
     component: props => {
@@ -59,20 +45,6 @@ const configurableFields = {
       return <div></div>;
     }
   },
-  MESSAGE_HANDLERS: {
-    schema: yup.string(),
-    ready: true,
-    component: props => {
-      // toggles on/off for each handler, needs a description of each
-      return (
-        <Form.Field
-          label="Message Handlers (comma-separated)"
-          name="MESSAGE_HANDLERS"
-          fullWidth
-        />
-      );
-    }
-  },
   opt_out_message: {
     schema: yup.string(),
     component: props => {
@@ -87,8 +59,8 @@ export default class OrganizationFeatureSettings extends React.Component {
     super(props);
     const { formValues } = this.props;
     const settingsData =
-      (formValues.settings.featuresJSON &&
-        JSON.parse(formValues.settings.featuresJSON)) ||
+      (formValues.defaultSettings.featuresJSON &&
+        JSON.parse(formValues.defaultSettings.featuresJSON)) ||
       {};
     this.state = { ...settingsData, unsetFeatures: [] };
   }
@@ -96,7 +68,7 @@ export default class OrganizationFeatureSettings extends React.Component {
   onChange = formValues => {
     this.setState(formValues, () => {
       this.props.onChange({
-        settings: {
+        defaultSettings: {
           featuresJSON: JSON.stringify(this.state),
           unsetFeatures: this.state.unsetFeatures
         }
@@ -107,7 +79,7 @@ export default class OrganizationFeatureSettings extends React.Component {
   toggleChange = (key, value) => {
     this.setState({ [key]: value }, newData => {
       this.props.onChange({
-        settings: {
+        defaultSettings: {
           featuresJSON: JSON.stringify(this.state),
           unsetFeatures: this.state.unsetFeatures
         }
@@ -116,8 +88,6 @@ export default class OrganizationFeatureSettings extends React.Component {
   };
 
   render() {
-    // message handlers add/remove
-    // action handlers: add/remove
     // features and unsetFeatures list
     const schemaObject = {};
     const adminItems = Object.keys(configurableFields)
@@ -135,6 +105,7 @@ export default class OrganizationFeatureSettings extends React.Component {
         >
           {adminItems}
           <Form.Button
+            key="OFS-submit"
             type="submit"
             onClick={this.props.onSubmit}
             label={this.props.saveLabel}

--- a/src/containers/Settings.jsx
+++ b/src/containers/Settings.jsx
@@ -270,7 +270,6 @@ class Settings extends React.Component {
     const formSchema = yup.object({
       optOutMessage: yup.string().required()
     });
-    console.log("props from settings: ", organization);
 
     return (
       <div>
@@ -397,8 +396,11 @@ class Settings extends React.Component {
             </CardText>
           </Card>
         ) : null}
-        {this.props.data.organization &&
-        this.props.data.organization.extensionSettings ? (
+        {organization &&
+        organization.extensionSettings &&
+        (organization.extensionSettings.allowedActionHandlers.length > 0 ||
+          organization.extensionSettings.allowedMessageHandlers.length > 0 ||
+          organization.extensionSettings.allowedContactLoaders.length > 0) ? (
           <Card>
             <CardHeader
               title="Extension Setting"
@@ -410,7 +412,6 @@ class Settings extends React.Component {
                 organization={this.props.data.organization}
                 onSubmit={async () => {
                   const { extensionSettings } = this.state;
-                  console.log("settings about to be set:", extensionSettings);
                   await this.props.mutations.editOrganization({
                     extensionSettings: {
                       ...extensionSettings,
@@ -422,7 +423,6 @@ class Settings extends React.Component {
                   this.setState({ extensionSettings: null });
                 }}
                 onChange={formValues => {
-                  console.log("FORM VALUES:", formValues);
                   this.setState(formValues);
                 }}
                 saveLabel="Save Extensions"
@@ -464,6 +464,7 @@ const queries = {
             allowedMessageHandlers
             allowedActionHandlers
             allowedContactLoaders
+            handlerDisplayInformation
           }
           texterUIConfig {
             options

--- a/src/containers/Settings.jsx
+++ b/src/containers/Settings.jsx
@@ -16,6 +16,7 @@ import Toggle from "material-ui/Toggle";
 import moment from "moment";
 import CampaignTexterUIForm from "../components/CampaignTexterUIForm";
 import OrganizationFeatureSettings from "../components/OrganizationFeatureSettings";
+import ExtensionSettings from "../components/ExtensionSettings";
 
 const styles = StyleSheet.create({
   section: {
@@ -356,7 +357,6 @@ class Settings extends React.Component {
                   this.setState({ texterUIConfig: null });
                 }}
                 onChange={formValues => {
-                  console.log("change", formValues);
                   this.setState(formValues);
                 }}
                 saveLabel="Save Texter UI Campaign Defaults"
@@ -384,7 +384,34 @@ class Settings extends React.Component {
                   this.setState({ settings: null });
                 }}
                 onChange={formValues => {
-                  console.log("change", formValues);
+                  this.setState(formValues);
+                }}
+                saveLabel="Save settings"
+                saveDisabled={!this.state.settings}
+              />
+            </CardText>
+          </Card>
+        ) : null}
+        {this.props.data.organization &&
+        this.props.data.organization.settings ? (
+          <Card>
+            <CardHeader
+              title="yay bob"
+              style={{ backgroundColor: theme.colors.green }}
+            />
+            <CardText>
+              <ExtensionSettings
+                formValues={this.props.data.organization}
+                organization={this.props.data.organization}
+                onSubmit={async () => {
+                  const { settings } = this.state;
+                  console.log("settings about to be set:", settings);
+                  await this.props.mutations.editOrganization({
+                    settings
+                  });
+                  this.setState({ settings: null });
+                }}
+                onChange={formValues => {
                   this.setState(formValues);
                 }}
                 saveLabel="Save settings"
@@ -418,6 +445,7 @@ const queries = {
           settings {
             messageHandlers
             actionHandlers
+            contactLoaders
             featuresJSON
             unsetFeatures
           }
@@ -447,6 +475,13 @@ export const editOrganizationGql = gql`
   ) {
     editOrganization(id: $organizationId, organization: $organizationChanges) {
       id
+      settings {
+        messageHandlers
+        actionHandlers
+        contactLoaders
+        featuresJSON
+        unsetFeatures
+      }
       texterUIConfig {
         options
         sideboxChoices

--- a/src/containers/Settings.jsx
+++ b/src/containers/Settings.jsx
@@ -270,6 +270,7 @@ class Settings extends React.Component {
     const formSchema = yup.object({
       optOutMessage: yup.string().required()
     });
+    console.log("props from settings: ", organization);
 
     return (
       <div>
@@ -400,7 +401,7 @@ class Settings extends React.Component {
         this.props.data.organization.extensionSettings ? (
           <Card>
             <CardHeader
-              title="yay bob"
+              title="Extension Setting"
               style={{ backgroundColor: theme.colors.green }}
             />
             <CardText>

--- a/src/containers/Settings.jsx
+++ b/src/containers/Settings.jsx
@@ -411,7 +411,12 @@ class Settings extends React.Component {
                   const { extensionSettings } = this.state;
                   console.log("settings about to be set:", extensionSettings);
                   await this.props.mutations.editOrganization({
-                    extensionSettings
+                    extensionSettings: {
+                      ...extensionSettings,
+                      allowedMessageHandlers: [],
+                      allowedActionHandlers: [],
+                      allowedContactLoaders: []
+                    }
                   });
                   this.setState({ extensionSettings: null });
                 }}

--- a/src/integrations/action-handlers/index.js
+++ b/src/integrations/action-handlers/index.js
@@ -206,3 +206,20 @@ export async function getActionChoiceData(actionHandler, organization, user) {
   }
   return items || [];
 }
+
+export function getHandlerDisplayName(name) {
+  try {
+    return require(`./${name}.js`).displayName();
+  } catch (exception) {
+    return "";
+  }
+}
+
+export function getHandlerDescription(name) {
+  try {
+    const serverAdministratorInstructions = require(`./${name}.js`).serverAdministratorInstructions();
+    return serverAdministratorInstructions.description;
+  } catch (exception) {
+    return "";
+  }
+}

--- a/src/integrations/contact-loaders/index.js
+++ b/src/integrations/contact-loaders/index.js
@@ -108,3 +108,20 @@ export async function getMethodChoiceData(
     )
   ).data;
 }
+
+export function getHandlerDisplayName(name) {
+  try {
+    return require(`./${name}/index.js`).displayName();
+  } catch (exception) {
+    return "";
+  }
+}
+
+export function getHandlerDescription(name) {
+  try {
+    const serverAdministratorInstructions = require(`./${name}/index.js`).serverAdministratorInstructions();
+    return serverAdministratorInstructions.description;
+  } catch (exception) {
+    return "";
+  }
+}

--- a/src/integrations/message-handlers/auto-optout/index.js
+++ b/src/integrations/message-handlers/auto-optout/index.js
@@ -2,6 +2,10 @@ import { getConfig } from "../../../server/api/lib/config";
 import { cacheableData, Message } from "../../../server/models";
 import serviceMap from "../../../server/api/lib/services";
 
+export function displayName() {
+  return "Auto Output";
+}
+
 export const serverAdministratorInstructions = () => {
   return {
     description: `

--- a/src/integrations/message-handlers/index.js
+++ b/src/integrations/message-handlers/index.js
@@ -19,3 +19,20 @@ export function getMessageHandlers(organization) {
   });
   return handlers;
 }
+
+export function getHandlerDisplayName(name) {
+  try {
+    return require(`./${name}/index.js`).displayName();
+  } catch (exception) {
+    return "";
+  }
+}
+
+export function getHandlerDescription(name) {
+  try {
+    const serverAdministratorInstructions = require(`./${name}/index.js`).serverAdministratorInstructions();
+    return serverAdministratorInstructions.description;
+  } catch (exception) {
+    return "";
+  }
+}

--- a/src/integrations/message-handlers/initaltext-guard/index.js
+++ b/src/integrations/message-handlers/initaltext-guard/index.js
@@ -2,6 +2,10 @@ import { getConfig } from "../../../server/api/lib/config";
 import { r, cacheableData, Message } from "../../../server/models";
 import serviceMap from "../../../server/api/lib/services";
 
+export function displayName() {
+  return "Initial Text Guard";
+}
+
 export const serverAdministratorInstructions = () => {
   return {
     description: `

--- a/src/integrations/message-handlers/ngpvan/index.js
+++ b/src/integrations/message-handlers/ngpvan/index.js
@@ -5,6 +5,10 @@ import { getActionChoiceData } from "../../../integrations/action-handlers";
 
 export const DEFAULT_NGP_VAN_INITIAL_TEXT_CANVASS_RESULT = "Texted";
 
+export function displayName() {
+  return "NGP VAN";
+}
+
 export const serverAdministratorInstructions = () => {
   return {
     description: `

--- a/src/integrations/message-handlers/profanity-tagger/index.js
+++ b/src/integrations/message-handlers/profanity-tagger/index.js
@@ -8,6 +8,10 @@ import { r, cacheableData } from "../../../server/models";
 export const DEFAULT_PROFANITY_REGEX_BASE64 =
   "ZmFrZXNsdXJ8XGJhc3NcYnxhc3Nob2xlfGJpdGNofGJsb3dqb2J8YnJvd25pZXxjaGlua3xjb2NrfGNvb258Y3Vja3xjdW50fGRhcmt5fGRpY2toZWFkfFxiZGllXGJ8ZmFnZ290fGZhaXJ5fGZhcnR8ZnJpZ2lkfGZ1Y2tib3l8ZnVja2VyfGdvb2t8aGVlYnxcYmhvZVxifFxiaG9tb1xifGppZ2Fib298a2lrZXxra2t8a3Uga2x1eCBrbGFufGxpY2sgbXxtYWNhY2F8bW9sZXN0fG15IGRpY2t8bXkgYXNzfG5lZ3JvfG5pZ2dlcnxuaWdyYXxwZWRvfHBpc3N8cHJpY2t8cHVzc3l8cXVpbXxyYXBlfHJldGFyZHxzaGVlbmllfHNoaXRoZWFkfHNoeWxvY2t8c2h5c3RlcnxzbHV0fHNwaWN8c3Bpa3xzdWNrIG15fHRhY29oZWFkfHRpdHN8dG93ZWxoZWFkfHRyYW5uaWV8dHJhbm55fFxidHVyZHx0dXJkXGJ8dHdhdHx3YW5rfHdldGJhY2t8d2hvcmV8eWlk";
 
+export function displayName() {
+  return "Profanity Tagger";
+}
+
 export const serverAdministratorInstructions = () => {
   return {
     description: `

--- a/src/server/api/mutations/editOrganization.js
+++ b/src/server/api/mutations/editOrganization.js
@@ -15,17 +15,24 @@ export const editOrganization = async (_, { id, organization }, { user }) => {
     changes["features"] = features;
   }
 
+  console.log("editOrg settings: ", organization.settings);
   if (organization.settings) {
     const { unsetFeatures, featuresJSON } = organization.settings;
+    console.log("editOrg featuresJson: ", featuresJSON);
+
     const newFeatureValues = JSON.parse(featuresJSON);
+    console.log("editOrg newFeatures: ", newFeatureValues);
     getAllowed(orgRecord, user).forEach(f => {
       if (newFeatureValues.hasOwnProperty(f)) {
         features[f] = newFeatureValues[f];
       }
     });
+    console.log("editOrg features first: ", features);
+
     unsetFeatures.forEach(f => {
       delete features[f];
     });
+    console.log("editOrg features then: ", features);
     changes["features"] = features;
   }
 

--- a/src/server/api/mutations/editOrganization.js
+++ b/src/server/api/mutations/editOrganization.js
@@ -12,29 +12,28 @@ export const editOrganization = async (_, { id, organization }, { user }) => {
   if (organization.texterUIConfig) {
     // update texterUIConfig
     features.TEXTER_UI_SETTINGS = organization.texterUIConfig.options;
-    changes["features"] = features;
   }
 
-  console.log("editOrg settings: ", organization.settings);
-  if (organization.settings) {
-    const { unsetFeatures, featuresJSON } = organization.settings;
-    console.log("editOrg featuresJson: ", featuresJSON);
-
+  if (organization.defaultSettings) {
+    const { unsetFeatures, featuresJSON } = organization.defaultSettings;
     const newFeatureValues = JSON.parse(featuresJSON);
-    console.log("editOrg newFeatures: ", newFeatureValues);
     getAllowed(orgRecord, user).forEach(f => {
-      if (newFeatureValues.hasOwnProperty(f)) {
-        features[f] = newFeatureValues[f];
+      if (newFeatureValues.hasOwnProperty(f) && !unsetFeatures.includes(f)) {
+        features.DEFAULT_SETTINGS[f] = newFeatureValues[f];
       }
     });
-    console.log("editOrg features first: ", features);
-
-    unsetFeatures.forEach(f => {
-      delete features[f];
-    });
-    console.log("editOrg features then: ", features);
-    changes["features"] = features;
   }
+
+  if (organization.extensionSettings) {
+    const updatedExtensionSettings = {
+      MESSAGE_HANDLERS: organization.extensionSettings.savedMessageHandlers,
+      ACTION_HANDLERS: organization.extensionSettings.savedActionHandlers,
+      CONTACT_LOADERS: organization.extensionSettings.savedContactLoaders
+    };
+    features.EXTENSION_SETTINGS = updatedExtensionSettings;
+  }
+
+  changes["features"] = features;
 
   if (Object.keys(changes).length) {
     if (changes.features) {

--- a/src/server/api/mutations/editOrganization.js
+++ b/src/server/api/mutations/editOrganization.js
@@ -26,9 +26,9 @@ export const editOrganization = async (_, { id, organization }, { user }) => {
 
   if (organization.extensionSettings) {
     const updatedExtensionSettings = {
-      MESSAGE_HANDLERS: organization.extensionSettings.savedMessageHandlers,
-      ACTION_HANDLERS: organization.extensionSettings.savedActionHandlers,
-      CONTACT_LOADERS: organization.extensionSettings.savedContactLoaders
+      MESSAGE_HANDLERS: organization.extensionSettings.savedMessageHandlers.join(),
+      ACTION_HANDLERS: organization.extensionSettings.savedActionHandlers.join(),
+      CONTACT_LOADERS: organization.extensionSettings.savedContactLoaders.join()
     };
     features.EXTENSION_SETTINGS = updatedExtensionSettings;
   }

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -138,27 +138,42 @@ export const resolvers = {
         return null;
       }
 
-      // reads from environment config, where these are individually set
+      // reads from global/environment config, where these are individually set
       const configurableSettings = getAllowed(organization, user);
+
+      const configurableMessageHandlers =
+        configurableSettings.includes("MESSAGE_HANDLERS") &&
+        getConfig("MESSAGE_HANDLERS");
       const allowedMessageHandlers =
-        (configurableSettings.MESSAGE_HANDLERS === 1 &&
-          getConfig("MESSAGE_HANDLERS")) ||
-        [];
+        configurableMessageHandlers !== undefined
+          ? configurableMessageHandlers.split(",")
+          : [];
+
+      const configurableActionHandlers =
+        configurableSettings.includes("ACTION_HANDLERS") &&
+        getConfig("ACTION_HANDLERS");
       const allowedActionHandlers =
-        (configurableSettings.ACTION_HANDLERS === 1 &&
-          getConfig("ACTION_HANDLERS")) ||
-        [];
+        configurableActionHandlers !== undefined
+          ? configurableActionHandlers.split(",")
+          : [];
+
+      const configurableContactLoaders =
+        configurableSettings.includes("CONTACT_LOADERS") &&
+        getConfig("CONTACT_LOADERS");
       const allowedContactLoaders =
-        (configurableSettings.CONTACT_LOADERS === 1 &&
-          getConfig("CONTACT_LOADERS")) ||
-        [];
+        configurableContactLoaders !== undefined
+          ? configurableContactLoaders.split(",")
+          : [];
 
       // reads from DB, where these are grouped under features.EXTENSION_SETTINGS
       const extensionSettings =
         getConfig("EXTENSION_SETTINGS", organization) || [];
-      let savedMessageHandlers = extensionSettings.MESSAGE_HANDLERS || [];
-      let savedActionHandlers = extensionSettings.ACTION_HANDLERS || [];
-      let savedContactLoaders = extensionSettings.CONTACT_LOADERS || [];
+      let savedMessageHandlers =
+        extensionSettings.MESSAGE_HANDLERS.split(",") || [];
+      let savedActionHandlers =
+        extensionSettings.ACTION_HANDLERS.split(",") || [];
+      let savedContactLoaders =
+        extensionSettings.CONTACT_LOADERS.split(",") || [];
 
       return {
         savedMessageHandlers,

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -136,8 +136,9 @@ export const resolvers = {
       } catch (err) {
         return null;
       }
-      let messageHandlers = [];
-      let actionHandlers = [];
+      let messageHandlers = null;
+      let actionHandlers = null;
+      let contactLoaders = null;
       const features = getFeatures(organization);
       const visibleFeatures = {};
       const unsetFeatures = [];
@@ -155,12 +156,17 @@ export const resolvers = {
           const globalActionHandlers = getConfig("ACTION_HANDLERS");
           actionHandlers =
             (globalActionHandlers && globalActionHandlers.split(",")) || [];
+        } else if (f === "CONTACT_LOADERS") {
+          const globalContactLoaders = getConfig("CONTACT_LOADERS");
+          contactLoaders =
+            (globalContactLoaders && globalContactLoaders.split(",")) || [];
         }
       });
 
       return {
         messageHandlers,
         actionHandlers,
+        contactLoaders,
         unsetFeatures,
         featuresJSON: JSON.stringify(visibleFeatures)
       };

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -6,9 +6,17 @@ import { accessRequired } from "./errors";
 import { getCampaigns } from "./campaign";
 import { buildUsersQuery } from "./user";
 import {
-  getAvailableActionHandlers,
-  getActionChoiceData
+  getHandlerDisplayName as getActionHandlerDisplayName,
+  getHandlerDescription as getActionHandlerDescription
 } from "../../integrations/action-handlers";
+import {
+  getHandlerDisplayName as getMessageHandlerDisplayName,
+  getHandlerDescription as getMessageHandlerDescription
+} from "../../integrations/message-handlers";
+import {
+  getHandlerDisplayName as getContactLoaderDisplayName,
+  getHandlerDescription as getContactLoaderDescription
+} from "../../integrations/contact-loaders";
 
 export const ownerConfigurable = {
   ACTION_HANDLERS: 1,
@@ -145,7 +153,8 @@ export const resolvers = {
         configurableSettings.includes("MESSAGE_HANDLERS") &&
         getConfig("MESSAGE_HANDLERS");
       const allowedMessageHandlers =
-        configurableMessageHandlers !== undefined
+        configurableMessageHandlers !== undefined &&
+        configurableMessageHandlers !== ""
           ? configurableMessageHandlers.split(",")
           : [];
 
@@ -153,7 +162,8 @@ export const resolvers = {
         configurableSettings.includes("ACTION_HANDLERS") &&
         getConfig("ACTION_HANDLERS");
       const allowedActionHandlers =
-        configurableActionHandlers !== undefined
+        configurableActionHandlers !== undefined &&
+        configurableActionHandlers !== ""
           ? configurableActionHandlers.split(",")
           : [];
 
@@ -161,7 +171,8 @@ export const resolvers = {
         configurableSettings.includes("CONTACT_LOADERS") &&
         getConfig("CONTACT_LOADERS");
       const allowedContactLoaders =
-        configurableContactLoaders !== undefined
+        configurableContactLoaders !== undefined &&
+        configurableContactLoaders != ""
           ? configurableContactLoaders.split(",")
           : [];
 
@@ -175,13 +186,45 @@ export const resolvers = {
       let savedContactLoaders =
         extensionSettings.CONTACT_LOADERS.split(",") || [];
 
+      // build display name and description dictionary for each handler
+      const displayInformationDictionary = {};
+      allowedContactLoaders.map(handler => {
+        const displayName = getContactLoaderDisplayName(handler);
+        const description = getContactLoaderDescription(handler);
+        displayInformationDictionary[handler] = {
+          displayName: displayName,
+          description: description
+        };
+      });
+      allowedActionHandlers.map(handler => {
+        const displayName = getActionHandlerDisplayName(handler);
+        const description = getActionHandlerDescription(handler);
+        displayInformationDictionary[handler] = {
+          displayName: displayName,
+          description: description
+        };
+      });
+      allowedMessageHandlers.map(handler => {
+        const displayName = getMessageHandlerDisplayName(handler);
+        const description = getMessageHandlerDescription(handler);
+        displayInformationDictionary[handler] = {
+          displayName: displayName,
+          description: description
+        };
+      });
+
+      const handlerDisplayInformation = JSON.stringify(
+        displayInformationDictionary
+      );
+
       return {
         savedMessageHandlers,
         savedActionHandlers,
         savedContactLoaders,
         allowedMessageHandlers,
         allowedActionHandlers,
-        allowedContactLoaders
+        allowedContactLoaders,
+        handlerDisplayInformation
       };
     },
     defaultSettings: async (organization, _, { user, loaders }) => {

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -17,6 +17,7 @@ export const ownerConfigurable = {
   MAX_CONTACTS_PER_TEXTER: 1,
   MAX_MESSAGE_LENGTH: 1,
   MESSAGE_HANDLERS: 1,
+  CONTACT_LOADERS: 1,
   opt_out_message: 1
 };
 
@@ -130,43 +131,65 @@ export const resolvers = {
           getConfig("ALLOW_SEND_ALL", organization, { truthy: 1 }) &&
           getFeatures(organization).ALLOW_SEND_ALL_ENABLED
       ),
-    settings: async (organization, _, { user, loaders }) => {
+    extensionSettings: async (organization, _, { user, loaders }) => {
       try {
         await accessRequired(user, organization.id, "OWNER", true);
       } catch (err) {
         return null;
       }
-      let messageHandlers = null;
-      let actionHandlers = null;
-      let contactLoaders = null;
-      const features = getFeatures(organization);
-      const visibleFeatures = {};
-      const unsetFeatures = [];
-      getAllowed(organization, user).forEach(f => {
-        if (features.hasOwnProperty(f)) {
-          visibleFeatures[f] = features[f];
-        } else {
-          unsetFeatures.push(f);
-        }
-        if (f === "MESSAGE_HANDLERS") {
-          const globalMessageHandlers = getConfig("MESSAGE_HANDLERS");
-          messageHandlers =
-            (globalMessageHandlers && globalMessageHandlers.split(",")) || [];
-        } else if (f === "ACTION_HANDLERS") {
-          const globalActionHandlers = getConfig("ACTION_HANDLERS");
-          actionHandlers =
-            (globalActionHandlers && globalActionHandlers.split(",")) || [];
-        } else if (f === "CONTACT_LOADERS") {
-          const globalContactLoaders = getConfig("CONTACT_LOADERS");
-          contactLoaders =
-            (globalContactLoaders && globalContactLoaders.split(",")) || [];
-        }
-      });
+
+      // reads from environment config, where these are individually set
+      const configurableSettings = getAllowed(organization, user);
+      const allowedMessageHandlers =
+        (configurableSettings.MESSAGE_HANDLERS === 1 &&
+          getConfig("MESSAGE_HANDLERS")) ||
+        [];
+      const allowedActionHandlers =
+        (configurableSettings.ACTION_HANDLERS === 1 &&
+          getConfig("ACTION_HANDLERS")) ||
+        [];
+      const allowedContactLoaders =
+        (configurableSettings.CONTACT_LOADERS === 1 &&
+          getConfig("CONTACT_LOADERS")) ||
+        [];
+
+      // reads from DB, where these are grouped under features.EXTENSION_SETTINGS
+      const extensionSettings =
+        getConfig("EXTENSION_SETTINGS", organization) || [];
+      let savedMessageHandlers = extensionSettings.MESSAGE_HANDLERS || [];
+      let savedActionHandlers = extensionSettings.ACTION_HANDLERS || [];
+      let savedContactLoaders = extensionSettings.CONTACT_LOADERS || [];
 
       return {
-        messageHandlers,
-        actionHandlers,
-        contactLoaders,
+        savedMessageHandlers,
+        savedActionHandlers,
+        savedContactLoaders,
+        allowedMessageHandlers,
+        allowedActionHandlers,
+        allowedContactLoaders
+      };
+    },
+    defaultSettings: async (organization, _, { user, loaders }) => {
+      try {
+        await accessRequired(user, organization.id, "OWNER", true);
+      } catch (err) {
+        return null;
+      }
+
+      // reads from DB, where these are grouped under features.DEFAULT_SETTINGS
+      const features = getConfig("DEFAULT_SETTINGS", organization) || null;
+      const visibleFeatures = {};
+      const unsetFeatures = [];
+      if (features !== null) {
+        getAllowed(organization, user).forEach(f => {
+          if (features.hasOwnProperty(f)) {
+            visibleFeatures[f] = features[f];
+          } else {
+            unsetFeatures.push(f);
+          }
+        });
+      }
+      return {
         unsetFeatures,
         featuresJSON: JSON.stringify(visibleFeatures)
       };


### PR DESCRIPTION
## Description
We added a new Extensions Settings panel to the Settings page; it has three sub-sections for the integration categories (action handlers, contact loaders, and message handlers) and will show toggles for the handlers available within them (based on environment variables). If no handlers are available for an integration category, we hide it. If no integration categories have available handlers, we hide the panel.

Saving works...seems to work, no bugs noticed atm.

# Checklist:
- [X] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [X] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ ] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] My PR is labeled [WIP] if it is in progress
