### PR TITLE
Possibly [WIP]: Add WSL to Readme for windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,26 +24,26 @@ Follow up instructions located [here](https://github.com/MoveOnOrg/Spoke/blob/ma
 
 Please let us know if you deployed by filling out this form [here](https://act.moveon.org/survey/tech/)
 
-## Getting started
+## Getting Started with Local Development
 
 ### Downloading
-
-1. Install either sqlite, postgres, or another [knex](http://knexjs.org/#Installation-client)-supported database.
-2. Install the Node version listed in `.nvmrc`. [NVM](https://github.com/creationix/nvm) is one way to do this (from the spoke directory):
+1. Download or clone Spoke into your local machine.  Note development will be significantly easier on Unix-based operation system.  If you choose to use Windows, you will likely have to download the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) and follow instructions on its download page.
+2. Install either sqlite, postgres, or another [knex](http://knexjs.org/#Installation-client)-supported database.
+3. Install the Node version listed in `.nvmrc`. [NVM](https://github.com/creationix/nvm) is one way to do this (from the spoke directory):
    ```
    nvm install
    nvm use
    ```
-3. Install yarn.
+4. Install yarn.
 
 - Yarn is a package manager that will download all required packages to run Spoke.
 - Install using the [directions provided by Yarn](https://yarnpkg.com/en/docs/install).
 
-4. Install the packages.
+5. Install the packages.
    ```
    yarn install
    ```
-5. Create a real environment file:
+6. Create a real environment file:
    ```
    cp .env.example .env
    ```


### PR DESCRIPTION
# Fixes # (issue)
Adds mention of WSL for windows users.

## Description
There is a lot of complexity in the setup process which I ultimately decided to avoid in the main readme.  I have included some of those notes for possible future inclusion.  This current PR will lead to a merge conflict with at least https://github.com/MoveOnOrg/Spoke/pull/1699/files . Furthermore, this might be a good time to reorganize the actual readme documentation.  This would involve splitting up the readme into different smaller documentation pages: https://github.com/MoveOnOrg/Spoke/issues/1728

## Possible things to include in additional documentation
Unfortunately, a lot of the setup may entail tweaks due to the quirks of an individual's development environment.  Due to the variety of the types of tweaks, I am unsure of what specifically to include in the local setup instructions.  These should be in their own windows setup page.

* Ultimately added: `For windows users: you will find it much easier to use windows subsystem for linux.  Setup for this can be found here - be sure to check out the troubleshooting tips at bottom of this linked page: https://docs.microsoft.com/en-us/windows/wsl/install-win10`
* Once WSL and your choice* of Linux is installed, and you cd or shift+right click into the spoke directory using WSL, you can follow the instructions as written - except when an error occurs - these errors will either be a) acceptable and ignorable, b) in these instructions, or c) to be addressed through a well formatted search engine query. * Note: perhaps should omit choice and only use Ubuntu or whichever is deemed easiest.
* to get permissions for your c drive run (unsure if this was needed):
```sudo umount /mnt/c```
```sudo mount -t drvfs C: /mnt/c -o metadata,uid=1000,gid=1000,umask=22,fmask=111```
And maybe (unsure) Afterwards, change the owner of `Microsoft Windows Subsystem for Linux Launcher` to be your user
* Note that certain issues may arise, particularly regarding permissions.  Whether sudo is to be used is confusing - and installing yarn does not give sudo access to the yarn "command" (aliased shell script, I believe)
* Possibly use npm instead of yarn?  Some steps with yarn vs npm - would like to retry this with just yarn
* At some point you'll have to restart - I am unsure of when.
* How does docker tie in? Possibly easier in a docker environment?  I did not try too much of docker as the instructions on use in readme were unclear.  Note that docker in windows requires a license (only included in enterprise windows), but WSL will not.
* getting psql (and psql into path) was a little bit of a special hassle: as described in this kind of sketchy article (not sure if more formal instructions exist) https://medium.com/@harshityadav95/postgresql-in-windows-subsystem-for-linux-wsl-6dc751ac1ff3 and might require `sudo -u postgres psql` instead of just psql
* might need `NVM for windows` even in WSL
* without WSL you will encounter ```$ if [ "$NODE_ENV" = production ] ; then npm run prod-build && npm run prod-static-upload && npm run install-config-file && npm run notify-slack; fi
"$NODE_ENV" was unexpected at this time.``` during `yarn install`

Note that once these steps are finally compiled, it will make sense to have a fresh computer go through the steps explicitly

# Checklist:

- [NA] I have manually tested my changes on desktop and mobile
- [X] The test suite passes locally with my changes
- [NA] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [X] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [X] I have made any necessary changes to the documentation
- [NA] I have added tests that prove my fix is effective or that my feature works
- [X] My PR is labeled [WIP] if it is in progress
