### PR TITLE
Additional fixes for Twilio validation

### DIFF
--- a/src/components/DisplayLink.jsx
+++ b/src/components/DisplayLink.jsx
@@ -3,23 +3,39 @@ import React from "react";
 import TextField from "material-ui/TextField";
 import { dataTest } from "../lib/attributes";
 
-const DisplayLink = ({ url, textContent }) => (
+const inlineStyles = {
+  displayLabel: {
+    display: "inline-block",
+    fontWeight: "bold",
+    marginRight: 10
+  },
+  fieldWithLabel: {
+    display: "inline-block",
+    width: "80%"
+  }
+};
+
+const DisplayLink = ({ url, textContent, label }) => (
   <div>
-    <div>{textContent}</div>
-    <TextField
-      {...dataTest("url")}
-      name={url}
-      value={url}
-      autoFocus
-      onFocus={event => event.target.select()}
-      fullWidth
-    />
+    {textContent ? <div>{textContent}</div> : null}
+    {label ? <label style={inlineStyles.displayLabel}>{label}</label> : null}
+    <div style={label ? inlineStyles.fieldWithLabel : ""}>
+      <TextField
+        {...dataTest("url")}
+        name={url}
+        value={url}
+        autoFocus
+        onFocus={event => event.target.select()}
+        fullWidth
+      />
+    </div>
   </div>
 );
 
 DisplayLink.propTypes = {
   url: PropTypes.string,
-  textContent: PropTypes.string
+  textContent: PropTypes.string,
+  label: PropTypes.string
 };
 
 export default DisplayLink;

--- a/src/containers/Settings.jsx
+++ b/src/containers/Settings.jsx
@@ -201,7 +201,12 @@ class Settings extends React.Component {
           <CardText style={inlineStyles.shadeBox}>
             <DisplayLink
               url={`${baseUrl}/twilio/${organization.id}`}
-              textContent="Twilio credentials are configured for this organization. You should set the inbound Request URL in your Twilio messaging service to this link."
+              label="Request URL"
+              textContent="Twilio credentials are configured for this organization. If you are mannually configiring a Twilio messaging service you should use these URLs."
+            />
+            <DisplayLink
+              url={`${baseUrl}/twilio-message-report/${organization.id}`}
+              label="Status Callback URL"
             />
           </CardText>
         )}

--- a/src/server/api/lib/twilio.js
+++ b/src/server/api/lib/twilio.js
@@ -289,8 +289,7 @@ async function sendMessage(message, contact, trx, organization, campaign) {
       {
         to: message.contact_number,
         body: message.text,
-        messagingServiceSid: messagingServiceSid,
-        statusCallback: process.env.TWILIO_STATUS_CALLBACK_URL
+        messagingServiceSid
       },
       twilioValidityPeriod ? { validityPeriod: twilioValidityPeriod } : {},
       parseMessageText(message)
@@ -538,7 +537,11 @@ async function createMessagingService(organization, friendlyName) {
   const twilioBaseUrl = getConfig("TWILIO_BASE_CALLBACK_URL", organization);
   return await twilio.messaging.services.create({
     friendlyName,
-    statusCallback: urlJoin(twilioBaseUrl, "twilio-message-report"),
+    statusCallback: urlJoin(
+      twilioBaseUrl,
+      "twilio-message-report",
+      organization.id.toString()
+    ),
     inboundRequestUrl: urlJoin(
       twilioBaseUrl,
       "twilio",


### PR DESCRIPTION
A few additional fixes related to #1826 

- Messaging services created by Spoke include the org ID
- Status callback url is no longer included in the twilio `sendMessage` function. The callback URL does not vary per-message, so it's better to allow it to use the callback set in the messaging service
- Add the org callback URL to the Setting page