### PR TITLE
Twilio ISV api extension

### DIFF
--- a/src/extensions/service-managers/twilio-isv/index.js
+++ b/src/extensions/service-managers/twilio-isv/index.js
@@ -1,0 +1,62 @@
+import { TwilioISV } from "./isv";
+
+/// All functions are OPTIONAL EXCEPT metadata() and const name=.
+/// DO NOT IMPLEMENT ANYTHING YOU WILL NOT USE -- the existence of a function adds behavior/UI (sometimes costly)
+
+export const name = "twilio-isv";
+
+export const metadata = () => ({
+  // set canSpendMoney=true, if this extension can lead to (additional) money being spent
+  // if it can, which operations below can trigger money being spent?
+  displayName: "Twilio ISV management",
+  description:
+    "If ISV api access has been enabled on your account, then you can manage/review brands/campaigns/etc",
+  canSpendMoney: true,
+  moneySpendingOperations: ["onOrganizationUpdateSignal"],
+  supportsOrgConfig: true,
+  supportsCampaignConfig: false
+});
+
+export async function getOrganizationData({ organization, user, loaders }) {
+  // MUST NOT RETURN SECRETS!
+  const isv = new TwilioISV({ organization });
+  const policies = await isv.getPolicies();
+  const profiles = await isv.getProfiles();
+  const brands = await isv.getBrands();
+  const endUsers = await isv.getEndUsers();
+
+  return {
+    // data is any JSON-able data that you want to send.
+    // This can/should map to the return value if you implement onOrganizationUpdateSignal()
+    // which will then get updated data in the Settings component on-save
+    data: {
+      policies,
+      profiles,
+      brands,
+      endUsers
+    },
+    // fullyConfigured: null means (more) configuration is optional -- maybe not required to be enabled
+    // fullyConfigured: true means it is fully enabled and configured for operation
+    // fullyConfigured: false means more configuration is REQUIRED (i.e. manager is necessary and needs more configuration for Spoke campaigns to run)
+    fullyConfigured: null
+  };
+}
+
+export async function onOrganizationServiceVendorSetup({
+  organization,
+  user,
+  serviceName,
+  oldConfig,
+  newConfig
+}) {}
+
+export async function onOrganizationUpdateSignal({
+  organization,
+  user,
+  updateData
+}) {
+  return {
+    data: updateData,
+    fullyConfigured: true
+  };
+}

--- a/src/extensions/service-managers/twilio-isv/isv.js
+++ b/src/extensions/service-managers/twilio-isv/isv.js
@@ -137,6 +137,31 @@ export class TwilioISV {
     // }
     return vettingResp;
   }
+
+  async listUseCases({ brandId, messageServiceSid }) {
+    const twilio = await this.client();
+    const useCases = await twilio.messaging
+      .services(messageServiceSid /*"MG...."*/)
+      .usAppToPersonUsecases.fetch({
+        brandRegistrationSid: brandId /*"BN..."*/
+      });
+    // maybe see what current
+  }
+
+  async createMessagingUseCase() {
+    /*
+    await twilio.messaging.services('MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+      .usAppToPerson
+      .create({
+         description: 'Send marketing messages about sales and offers',
+         usAppToPersonUsecase: 'MARKETING',
+         hasEmbeddedLinks: true,
+         hasEmbeddedPhone: true,
+         brandRegistrationSid: 'BNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+         messageSamples: ['message_samples']
+       })
+    */
+  }
 }
 
 // MOCK BRANDS:

--- a/src/extensions/service-managers/twilio-isv/isv.js
+++ b/src/extensions/service-managers/twilio-isv/isv.js
@@ -1,0 +1,109 @@
+import { getTwilio } from "../../service-vendors/twilio";
+
+// Nonprofit and Government Guide to A2P 10DLC Text Messaging
+// https://support.twilio.com/hc/en-us/articles/4405850570267-Nonprofit-and-Government-Guide-to-A2P-10DLC-Text-Messaging
+// API walkthrough
+// https://www.twilio.com/docs/sms/a2p-10dlc/onboarding-isv-api
+// API setup options
+// https://www.twilio.com/docs/sms/a2p-10dlc/onboarding-isv#1-create-a-twilio-business-profile-in-trust-hub
+
+export class TwilioISV {
+  constructor({ organization, limit, debug }) {
+    this.organization = organization;
+    if (!organization || !organization.id) {
+      throw new Error("TwilioISV must include organization argument");
+    }
+    this.limit = limit || 20;
+    this.debug = debug;
+  }
+
+  async client() {
+    if (!this.twilio) {
+      this.twilio = await getTwilio(this.organization);
+    }
+    return this.twilio;
+  }
+
+  async getPolicies() {
+    const twilio = await this.client();
+    const policies = await twilio.trusthub.policies.list({ limit: this.limit });
+    if (this.debug) console.log("POLICIES", policies);
+    return policies;
+  }
+
+  async getPolicySecondary() {
+    const twilio = await this.client();
+    // hard-coded policy id for secondary policy
+    const policy = await twilio.trusthub
+      .policies("RNdfbf3fae0e1107f8aded0e7cead80bf5")
+      .fetch();
+    return policy;
+  }
+
+  async getProfiles() {
+    const twilio = await this.client();
+    const profiles = await twilio.trusthub.customerProfiles.list({
+      limit: this.limit
+    });
+    if (this.debug) console.log("PROFILES", profiles);
+    return profiles;
+  }
+
+  async getEntityAssignments(trustProductSid) {
+    const twilio = await this.client();
+    // trustProductSids look like 'BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+    const assignments = await twilio.trusthub
+      .trustProducts(trustProductSid)
+      .trustProductsEntityAssignments.list({ limit: this.limit });
+    if (this.debug) console.log("ASSIGNMENTS", assignments);
+    return assignments;
+  }
+
+  async getEndUsers() {
+    // combination of representatives and address info
+    const twilio = await this.client();
+    const endUsers = await twilio.trusthub.endUsers.list({ limit: this.limit });
+    if (this.debug) console.log("END-USERS", endUsers);
+    return endUsers;
+  }
+
+  async getBrands() {
+    const twilio = await this.client();
+    const brands = await twilio.messaging.brandRegistrations.list({
+      limit: this.limit
+    });
+    if (this.debug) console.log("BRANDS", brands);
+    return brands;
+  }
+}
+
+// MOCK BRANDS:
+// Mock Brands and campaigns expire after 30 days. After the 30 day period, your mock brand will become invalid and expire.
+// You cannot delete a mock brand. You must wait until the mock brand expires. Mock Campaigns can be deleted as described above.
+// There are no billing events from mock brand or mock campaign creation.
+
+// MOCK BRAND CREATION
+// client.messaging.brandRegistrations
+//       .create({
+//          brandType: 'STARTER',
+//          mock: true,
+//          customerProfileBundleSid: 'BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX0',
+//          a2PProfileBundleSid: 'BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX1'
+//        }).then(brand_registration => console.log(brand_registration.sid));
+
+// A2P CAMPAIGN REGISTRATION
+// client.messaging.services('MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+//       .usAppToPerson
+//       .create({
+//          brandRegistrationSid: 'BNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+//          description: 'Send marketing messages about sales and offers',
+//          messageSamples: ['Twilio draw the OWL event is ON'],
+//          usAppToPersonUsecase: 'STARTER',
+//          hasEmbeddedLinks: true,
+//          hasEmbeddedPhone: true
+//        }).then(us_app_to_person => console.log(us_app_to_person.sid));
+//
+// A2P CAMPAIGN REMOVAL/DELETION
+// client.messaging.services('MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+//                 .usAppToPerson('QE2c6890da8086d771620e9b13fadeba0b')
+//                 .remove();

--- a/src/extensions/service-managers/twilio-isv/react-component.js
+++ b/src/extensions/service-managers/twilio-isv/react-component.js
@@ -1,0 +1,82 @@
+/* eslint no-console: 0 */
+import { css } from "aphrodite";
+import PropTypes from "prop-types";
+import React from "react";
+import Form from "react-formal";
+import * as yup from "yup";
+import DisplayLink from "../../../components/DisplayLink";
+import GSForm from "../../../components/forms/GSForm";
+import GSTextField from "../../../components/forms/GSTextField";
+import GSSubmitButton from "../../../components/forms/GSSubmitButton";
+
+export class OrgConfig extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  render() {
+    console.log("twilio-isv OrgConfig", this.props);
+    if (
+      !this.props.serviceManagerInfo.data ||
+      !this.props.serviceManagerInfo.data.policies
+    ) {
+      return <div>Current Twilio account does not have ISV access</div>;
+    }
+    const {
+      policies,
+      profiles,
+      brands,
+      endUsers
+    } = this.props.serviceManagerInfo.data;
+
+    return (
+      <div>
+        {profiles.map(prof => {
+          const profBrands = brands.filter(
+            b => b.customerProfileBundleSid === prof.sid
+          );
+          return (
+            <div key={prof.sid}>
+              <b>{prof.friendlyName}</b> - {prof.sid} for account{" "}
+              {prof.accountSid}
+              <div>
+                Status: {prof.status}
+                <br />
+                Created: {prof.dateCreated}
+                <br />
+                Updated: {prof.dateUpdated}
+              </div>
+              {profBrands.length ? (
+                <ul>
+                  <lh>
+                    <b>Brands/Brand Registrations</b>
+                  </lh>
+                  {profBrands.map(bnd => (
+                    <li>
+                      <i>{bnd.sid}</i> status: {bnd.status}
+                      <br />
+                      {bnd.failureReason ? `Failure: ${bnd.failureReason}` : ""}
+                      {bnd.tcrId ? `tcrId: ${bnd.tcrId}` : ""}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                ""
+              )}
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+}
+
+OrgConfig.propTypes = {
+  organizationId: PropTypes.string,
+  serviceManagerInfo: PropTypes.object,
+  inlineStyles: PropTypes.object,
+  styles: PropTypes.object,
+  saveLabel: PropTypes.string,
+  onSubmit: PropTypes.func
+};

--- a/src/server/models/thinky.js
+++ b/src/server/models/thinky.js
@@ -61,6 +61,9 @@ if (redisUrl) {
       agent: false
     };
   }
+  if (process.env.CACHE_PREFIX) {
+    redisSettings.prefix = process.env.CACHE_PREFIX;
+  }
   if (process.env.REDIS_JSON) {
     Object.assign(redisSettings, JSON.parse(process.env.REDIS_JSON));
   }


### PR DESCRIPTION
This begins a service-vendor extension that supports some basic tooling on how to interact with the Twilio ISV api -- currently this requires  you to request access to the api from Twilio. The ISV api allows you to register/create/list TrustHub profiles, brands, registrations, etc. 

* Lists profiles and brands connected to them
* Connect a CampaignVerify token to an existing Brand