### PR TITLE
Add isOptedOut field to allContactsCount and set to false

### DIFF
--- a/src/containers/TexterTodo.jsx
+++ b/src/containers/TexterTodo.jsx
@@ -157,7 +157,7 @@ export const dataQuery = gql`
       contacts(contactsFilter: $contactsFilter) {
         id
       }
-      allContactsCount: contactsCount
+      allContactsCount: contactsCount(contactsFilter: { isOptedOut: false })
       unmessagedCount: contactsCount(contactsFilter: $needsMessageFilter)
       unrepliedCount: contactsCount(contactsFilter: $needsResponseFilter)
       texter {


### PR DESCRIPTION
# Fixes #2003 

## Description

- Previously, when a texter had a contact listed which included contacts who had opted out from another campaign, those opt-outs were not being excluded from that texter's number of remaining texts to send
- `src/containers/TexterTodo.jsx`: Add `isOptedOut` field to `allContactsCount` and set value to `false`
- Test to ensure opt-out status persists across campaigns when creating a new campaign
- Test to ensure that, if same contacts are loaded to two new campaigns simultaneously, the second campaign's total contacts update when a shared contact opts out of the first campaign

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
