### PR TITLE
2082 stop overwriting campaign edits

### DIFF
--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -41,6 +41,10 @@ import { styles } from "./AdminCampaignStats";
 import AdminScriptImport from "../containers/AdminScriptImport";
 import { makeTree } from "../lib";
 
+const CAMPAIGN_POLLING_INTERVAL = 60000;
+const JOB_WAITING_POLLING_INTERVAL = 2500;
+const ORG_POLLING_INTERVAL = 20000;
+
 const campaignInfoFragment = `
   id
   title
@@ -168,7 +172,7 @@ export class AdminCampaignEdit extends React.Component {
         {
           isPolling: true
         },
-        () => this.props.campaignData.startPolling(2500)
+        () => this.props.campaignData.startPolling(JOB_WAITING_POLLING_INTERVAL)
       );
     }
   };
@@ -181,7 +185,7 @@ export class AdminCampaignEdit extends React.Component {
           isPolling: false
         },
         () => {
-          this.props.campaignData.stopPolling();
+          this.props.campaignData.startPolling(CAMPAIGN_POLLING_INTERVAL);
         }
       );
     }
@@ -1065,7 +1069,7 @@ const queries = {
       variables: {
         campaignId: ownProps.params.campaignId
       },
-      pollInterval: 60000
+      pollInterval: CAMPAIGN_POLLING_INTERVAL
     })
   },
   organizationData: {
@@ -1106,7 +1110,7 @@ const queries = {
       variables: {
         organizationId: ownProps.params.organizationId
       },
-      pollInterval: 20000
+      pollInterval: ORG_POLLING_INTERVAL
     })
   }
 };

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -213,18 +213,29 @@ export class AdminCampaignEdit extends React.Component {
       expandedKeys = expandedSection.keys;
     }
 
-    const unsavedKeys = [];
+    const keysInUnsavedSections = [];
     this.sections().forEach(section => {
       if (!this.checkSectionSaved(section)) {
-        unsavedKeys.push(...section.keys);
+        keysInUnsavedSections.push(...section.keys);
       }
     });
+
+    const newCampaignData = newProps.campaignData.campaign;
+    const changedKeysInUnsavedSections = [];
+    keysInUnsavedSections.forEach(key => {
+      if (newCampaignData[key] !== this.state.campaignFormValues[key]) {
+        changedKeysInUnsavedSections.push(key);
+      }
+    });
+
+    const doNotUpdateKeys = [
+      ...new Set([...changedKeysInUnsavedSections, ...expandedKeys])
+    ];
 
     const campaignDataCopy = {
       ...newProps.campaignData.campaign
     };
 
-    const doNotUpdateKeys = [...new Set([...unsavedKeys, ...expandedKeys])];
     doNotUpdateKeys.forEach(key => {
       // contactsCount is in two sections
       // That means it won't get updated if *either* is opened

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -228,19 +228,19 @@ export class AdminCampaignEdit extends React.Component {
     // find keys in unsaved sections that were changed by the user
     // we'll assume a key was changed by the user if its value is
     // different than the key's value in the last props we received
-    const changedKeysInUnsavedSections = [];
+    const keysInUnsavedSectionsChangedByTheUser = [];
     keysInUnsavedSections.forEach(key => {
       if (
         this.state.lastCampaignProps[key] !== this.state.campaignFormValues[key]
       ) {
-        changedKeysInUnsavedSections.push(key);
+        keysInUnsavedSectionsChangedByTheUser.push(key);
       }
     });
 
     // don't update keys in the open section as well as unsaved keys changed
     // by the user in closed sections
     const doNotUpdateKeys = [
-      ...new Set([...changedKeysInUnsavedSections, ...expandedKeys])
+      ...new Set([...keysInUnsavedSectionsChangedByTheUser, ...expandedKeys])
     ];
 
     const campaignDataCopy = {

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -206,17 +206,26 @@ export class AdminCampaignEdit extends React.Component {
     // 3. Refetch/poll updates data in loadData component wrapper
     //    and triggers *this* method => this.props.campaignData => this.state.campaignFormValues
     // So campaignFormValues should always be the diffs between server and client form data
-    let { expandedSection, isPolling } = this.state;
+    let { expandedSection } = this.state;
     let expandedKeys = [];
     if (expandedSection !== null) {
       expandedSection = this.sections()[expandedSection];
       expandedKeys = expandedSection.keys;
     }
 
+    const unsavedKeys = [];
+    this.sections().forEach(section => {
+      if (!this.checkSectionSaved(section)) {
+        unsavedKeys.push(...section.keys);
+      }
+    });
+
     const campaignDataCopy = {
       ...newProps.campaignData.campaign
     };
-    expandedKeys.forEach(key => {
+
+    const doNotUpdateKeys = [...new Set([...unsavedKeys, ...expandedKeys])];
+    doNotUpdateKeys.forEach(key => {
       // contactsCount is in two sections
       // That means it won't get updated if *either* is opened
       // but we want it to update in either

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -160,6 +160,7 @@ export class AdminCampaignEdit extends React.Component {
     this.state = {
       expandedSection,
       campaignFormValues: props.campaignData.campaign,
+      lastCampaignProps: props.campaignData.campaign,
       startingCampaign: false,
       isPolling: false
     };
@@ -213,6 +214,8 @@ export class AdminCampaignEdit extends React.Component {
       expandedKeys = expandedSection.keys;
     }
 
+    // look at all the unsaved sections
+    // get all the keys in the unsaved sections
     const keysInUnsavedSections = [];
     this.sections().forEach(section => {
       if (!this.checkSectionSaved(section)) {
@@ -221,13 +224,21 @@ export class AdminCampaignEdit extends React.Component {
     });
 
     const newCampaignData = newProps.campaignData.campaign;
+
+    // find keys in unsaved sections that were changed by the user
+    // we'll assume a key was changed by the user if its value is
+    // different than the key's value in the last props we received
     const changedKeysInUnsavedSections = [];
     keysInUnsavedSections.forEach(key => {
-      if (newCampaignData[key] !== this.state.campaignFormValues[key]) {
+      if (
+        this.state.lastCampaignProps[key] !== this.state.campaignFormValues[key]
+      ) {
         changedKeysInUnsavedSections.push(key);
       }
     });
 
+    // don't update keys in the open section as well as unsaved keys changed
+    // by the user in closed sections
     const doNotUpdateKeys = [
       ...new Set([...changedKeysInUnsavedSections, ...expandedKeys])
     ];
@@ -274,7 +285,8 @@ export class AdminCampaignEdit extends React.Component {
     }
 
     this.setState({
-      campaignFormValues: pushToFormValues
+      campaignFormValues: pushToFormValues,
+      lastCampaignProps: newCampaignData
     });
   }
 


### PR DESCRIPTION
# Fixes #2082 

## Description

### Change that fixes the issue
In `AdminCampaignEdit` we poll for updated data by design. 

Before, the polling would result in unsaved user changes in closed sections being overwritten. We prevented data from being updated in the open section.

This PR makes it so that updates do not overwrite changed data in any section in which the user changed something and closed the section without saving. 

### Additional change

When we had pending jobs, we changed the polling interval from 60 seconds to 2.5 seconds. When there were no more pending jobs, rather than setting the polling interval back to 60 seconds, we stopped polling altogether. This PR sets the polling inteval back to 60 seconds.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
