### PR TITLE
Add error catching for s3-pull batch insert

### DIFF
--- a/src/extensions/contact-loaders/s3-pull/index.js
+++ b/src/extensions/contact-loaders/s3-pull/index.js
@@ -187,7 +187,9 @@ export async function loadContactS3PullProcessFile(jobEvent, contextVars) {
       return { alreadyComplete: 1 };
     }
 
-    await r.knex.batchInsert("campaign_contact", insertRows);
+    await r.knex.batchInsert("campaign_contact", insertRows).catch(e => {
+      console.log("Error with S3 pull batch insertion for campaign", campaign_id, e);
+    });
   }
 
   if (fileIndex < manifestData.entries.length - 1) {

--- a/src/extensions/contact-loaders/s3-pull/index.js
+++ b/src/extensions/contact-loaders/s3-pull/index.js
@@ -188,7 +188,7 @@ export async function loadContactS3PullProcessFile(jobEvent, contextVars) {
     }
 
     await r.knex.batchInsert("campaign_contact", insertRows).catch(e => {
-      console.log("Error with S3 pull batch insertion for campaign", campaign_id, e);
+      console.error("Error with S3 pull batch insertion for campaign", campaign_id, e);
     });
   }
 


### PR DESCRIPTION
# Fixes #2236 

## Description

Originally, I wanted to add tests for this change, but then I found that there currently aren't any existing tests for the s3-pull feature. I started trying to write tests for it, and discovered that it's going to be a complicated task due to the need to mock the `AWS.S3` function: https://github.com/MoveOnOrg/Spoke/blob/2e8c479ef7e4071bc903bdf882334488b50f2910/src/extensions/contact-loaders/s3-pull/index.js#L92

This PR is a small change that adds a line of error catching, so I don't think a test is necessary for this. I created a new feature request to add tests to the s3-pull extension: https://github.com/MoveOnOrg/Spoke/issues/2249

# Checklist:

- [X] I have manually tested my changes on desktop and mobile
- [X] The test suite passes locally with my changes
- [X] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [X] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [X] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] My PR is labeled [WIP] if it is in progress
