### PR TITLE
Get contactTimezones when not caching

### DIFF
--- a/src/server/models/cacheable_queries/campaign.js
+++ b/src/server/models/cacheable_queries/campaign.js
@@ -206,7 +206,9 @@ const load = async (id, opts) => {
     }
   }
 
-  return await Campaign.get(id);
+  const campaign = await Campaign.get(id)
+  campaign.contactTimezones = await dbContactTimezones(id);
+  return campaign;
 };
 
 const campaignCache = {


### PR DESCRIPTION
# Fixes #2299 

## Description

Sets contactTimezones for the campaign when Redis isn't enabled.

# Checklist:

- [X] I have manually tested my changes on desktop and mobile
- [X] The test suite passes locally with my changes
- [X] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [X] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [X] I have made any necessary changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [X] My PR is labeled [WIP] if it is in progress
