### PR TITLE
Compatibility for Postgres 15

### DIFF
--- a/dev-tools/create-test-database
+++ b/dev-tools/create-test-database
@@ -6,3 +6,7 @@ docker-compose exec -T postgres psql -h localhost -p 5432 -U spoke spokedev <<EO
        CREATE USER spoke_test WITH PASSWORD 'spoke_test';
        GRANT ALL PRIVILEGES ON DATABASE spoke_test TO spoke_test;
 EOF
+
+docker-compose exec -T postgres psql -h localhost -p 5432 -U spoke spoke_test <<EOF
+       GRANT ALL ON SCHEMA public TO spoke_test;
+EOF


### PR DESCRIPTION
# Fixes #2304 

## Description
Explicitly give the `spoke_test` user privileges on the `public` schema.

# Checklist:

- [X] I have manually tested my changes on desktop and mobile
- [X] The test suite passes locally with my changes
- [X] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [X] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [X] I have made any necessary changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] My PR is labeled [WIP] if it is in progress
