### PR TITLE
Docker compose user settings from .env or defaults

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,20 +4,20 @@ services:
     image: postgres:alpine
     restart: always
     environment:
-      POSTGRES_DB: spokedev
-      POSTGRES_PASSWORD: spoke
-      POSTGRES_USER: spoke
+      POSTGRES_DB: ${DB_NAME:-spokedev}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-spoke}
+      POSTGRES_USER: ${DB_USER:-spoke}
     volumes:
       - postgres:/var/lib/postgresql/data
     ports:
-      - 5432:5432
+      - ${DB_PORT:-5432}:5432
   redis:
     image: redis:alpine
     restart: always
     volumes:
       - redis:/data
     ports:
-      - 6379:6379
+      - ${REDIS_PORT:-6379}:6379
 volumes:
   postgres:
     external: false


### PR DESCRIPTION
## Description

Have the docker compose file look for settings in `.env` and use defaults if they are not present.

This is a convenience for local development. If someone is working on multiple projects, this will enable them to run multiple instances of `postgres` and `redis` on their local machine.

The relevant entries in my `.env` file are

```
REDIS_PORT=16379
DB_USER=spokedev
DB_PORT=15432
DB_NAME=spokedev
DB_PASSWORD=spokedev
```



# Checklist:

- [ ] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ ] [My change is 300 lines of code or less](https://github.com/StateVoicesNational/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
