### PR TITLE
Update HOWTO_DEVELOPMENT_LOCAL_SETUP.md for more recent versions of D…

### DIFF
--- a/docs/HOWTO_DEVELOPMENT_LOCAL_SETUP.md
+++ b/docs/HOWTO_DEVELOPMENT_LOCAL_SETUP.md
@@ -76,7 +76,7 @@ Docker is optional, but can help with a consistent development environment using
 1. Install docker and docker compose
 
 - Docker allows you to run apps in containers and can be installed [here with Docker's instructions](https://docs.docker.com/desktop/)
-- Docker Compose is the tool used to create and run docker configurations. If you installed Docker on Mac, you already have Docker Compose, if you're using Linux or Windows you can install Docker Compose [with these instructions](https://docs.docker.com/compose/install/)
+- Docker Compose is the tool used to create and run docker configurations. If you installed Docker on Mac, a good way to install Docker Compose is to use [homebrew](https://brew.sh/). Once you have homebrew set up, you can run `brew install docker-compose`. if you're using Linux or Windows you can install Docker Compose [with these instructions](https://docs.docker.com/compose/install/)
 
 2. Make sure Docker is running on your machine and then build and run Spoke with `docker-compose up -d` to run redis and postgres in the background
    - You can stop docker compose at any time with `docker-compose down`, and data will persist next time you run `docker-compose up`.


### PR DESCRIPTION
…ocker that don't include docker-compose

Noticed today when I updated Docker that it no longer comes with docker-compose on Mac. Added instructions for how I installed it.

# Checklist:

- [x] [My change is 300 lines of code or less](https://github.com/StateVoicesNational/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
