### PR TITLE
Added script msg preview feature.

### DIFF
--- a/src/components/forms/GSScriptField.jsx
+++ b/src/components/forms/GSScriptField.jsx
@@ -9,6 +9,7 @@ import { allScriptFields } from "../../lib/scripts";
 import ScriptEditor from "../ScriptEditor";
 import { dataTest } from "../../lib/attributes";
 import theme from "../../styles/mui-theme";
+import { applyScript } from "../../lib/scripts";
 
 const styles = {
   dialog: {
@@ -55,6 +56,24 @@ export default class GSScriptField extends GSFormField {
     this.props.onChange(value);
     this.handleCloseDialog();
   };
+  
+  // Upon the successful upload of the CSV file, the file data will be persisted in localStorage, from which is can be retrieved here to generate the preview message.
+  previewScript = () => {
+    // Get contactCollection from localStorage
+    const contactCollection = JSON.parse(localStorage.getItem("contactCollection"));
+    
+    const { contacts, customFields } = contactCollection
+    
+    const currentScipt = this.state.script;
+    
+    let previewText = applyScript({
+      script: currentScipt,
+      contact: contacts[0],
+      customFields,
+      texter: {}
+    })
+    alert(`Script: \n${previewText}`)
+  };
 
   renderDialog() {
     const { open } = this.state;
@@ -97,6 +116,15 @@ export default class GSScriptField extends GSFormField {
             onClick={this.handleSaveScript}
           >
             Done
+          </Button>
+          
+          <Button
+            variant="contained"
+            color="primary"
+            {...dataTest("scriptPreview")}
+            onClick={this.previewScript}
+          >
+            Preview
           </Button>
         </DialogActions>
       </Dialog>

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -927,6 +927,8 @@ export class AdminCampaignEditBase extends React.Component {
                   // check to see if the startCampaign job completed
                   this.startPollingIfNecessary();
                 }
+                
+                localStorage.clear();
               }}
             >
               Start This Campaign!

--- a/src/extensions/contact-loaders/csv-upload/react-component.js
+++ b/src/extensions/contact-loaders/csv-upload/react-component.js
@@ -76,7 +76,8 @@ export class CampaignContactsFormBase extends React.Component {
   state = {
     uploading: false,
     validationStats: null,
-    contactUploadError: null
+    contactUploadError: null,
+    contacts: null
   };
 
   styles = StyleSheet.create({
@@ -154,7 +155,8 @@ export class CampaignContactsFormBase extends React.Component {
       customFields,
       uploading: false,
       contactUploadError: null,
-      contactsCount: contacts.length
+      contactsCount: contacts.length,
+      contacts
     });
     const contactCollection = {
       name: (file && file.name) || null,
@@ -162,6 +164,10 @@ export class CampaignContactsFormBase extends React.Component {
       customFields,
       contacts
     };
+    
+    // Write to local storage
+    localStorage.setItem("contactCollection", JSON.stringify(contactCollection));
+    
     const self = this;
     // uncomment here to make the data uncompressed on-upload
     // occasionally useful for debugging to see decoded data in-transit


### PR DESCRIPTION
# Fixes # (issue)
- Skills assessment prompt-2 feature request

## Description

Added a message preview that fully renders all custom fields from a custom script. If you upload a list of contacts with  custom fields, all fields should fully render into your designed message preview that is rendered through the browser Alert 
API pop-up. The message is viewable from the create campaign administrator view.


When you click into the input form of the script, there is now a third button that is labeled "Preview" as shown in the circled button of image below:
<img width="757" alt="script-preview" src="https://github.com/StateVoicesNational/Spoke/assets/60985926/853333f6-cb56-4601-ba83-37260bef93c9">

# Checklist:
- [ ] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ ] [My change is 300 lines of code or less](https://github.com/StateVoicesNational/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
