### PR TITLE
upgrade depricated api call for material-ui

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,7 +1,7 @@
 import PropTypes from "prop-types";
 import React, { useState } from "react";
 import { ThemeProvider } from "@material-ui/core/styles";
-import { createMuiTheme } from "@material-ui/core/styles";
+import { createTheme } from '@material-ui/core/styles'
 import CssBaseline from "@material-ui/core/CssBaseline";
 
 import { defaultTheme } from "../styles/mui-theme";
@@ -21,10 +21,10 @@ const formatTheme = newTheme => {
 
 const App = ({ children }) => {
   const [theme, setTheme] = useState(defaultTheme);
-  let muiTheme = createMuiTheme(defaultTheme);
+  let muiTheme = createTheme(defaultTheme);
   try {
     // if a bad value is saved this will fail.
-    muiTheme = createMuiTheme(theme);
+    muiTheme = createTheme(theme);
   } catch (e) {
     console.error("failed to create theme", theme);
   }

--- a/src/styles/mui-theme.js
+++ b/src/styles/mui-theme.js
@@ -1,4 +1,4 @@
-import { createMuiTheme } from "@material-ui/core/styles";
+import { createTheme } from "@material-ui/core/styles";
 
 /**
  * This is the default theme to be used in the app
@@ -22,7 +22,7 @@ const defaultTheme = {
   }
 };
 
-let theme = createMuiTheme(defaultTheme);
+let theme = createTheme(defaultTheme);
 
 export { defaultTheme };
 


### PR DESCRIPTION
# Fixes # (issue)

This api was updated and will be removed in the next version. Currently the below error is showing.

![image](https://github.com/StateVoicesNational/Spoke/assets/87616/f854d54e-8a94-499b-a90e-44b491407007)


## Description

updated api call. This deprivation happened in material-ui 4.12.0 which is in the yarn.lock file. No functional change should exist.

_Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change, and any blockers that make your change a WIP_

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/StateVoicesNational/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
