### PR TITLE
Documentation for ComposeV2

### DIFF
--- a/dev-tools/create-test-database
+++ b/dev-tools/create-test-database
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-docker-compose exec -T postgres psql -h localhost -p 5432 -U spoke spokedev <<EOF
+docker compose exec -T postgres psql -h localhost -p 5432 -U spoke spokedev <<EOF
        CREATE DATABASE spoke_test;
        CREATE USER spoke_test WITH PASSWORD 'spoke_test';
        GRANT ALL PRIVILEGES ON DATABASE spoke_test TO spoke_test;

--- a/dev-tools/psql
+++ b/dev-tools/psql
@@ -9,4 +9,4 @@
 
 set -euo pipefail
 
-docker-compose exec postgres psql  -h localhost -p 5432 -U spoke spokedev "$@"
+docker compose exec postgres psql  -h localhost -p 5432 -U spoke spokedev "$@"

--- a/dev-tools/redis-cli
+++ b/dev-tools/redis-cli
@@ -8,4 +8,4 @@ set -euo pipefail
 #   * To open a shell:    ./dev-tools/redis-cli
 #   * To clear the cache: ./dev-tools/redis-cli FLUSHDB
 
-docker-compose exec redis redis-cli "$@"
+docker compose exec redis redis-cli "$@"

--- a/docs/HOWTO-run_tests.md
+++ b/docs/HOWTO-run_tests.md
@@ -7,7 +7,7 @@ There are current two ways to run tests, using either PostgreSQL or SQLite.
 ### Running Postgres with Docker (recommended)
 
 1. Install [Docker](https://docs.docker.com/desktop/)
-2. Run redis and postgres using docker-compose: `docker-compose up`
+2. Run redis and postgres using docker compose: `docker compose up`
 3. Create the test database: `./dev-tools/create-test-database`
 4. Run `yarn test`
  

--- a/docs/HOWTO_AZURE_DEPLOY.md
+++ b/docs/HOWTO_AZURE_DEPLOY.md
@@ -65,7 +65,7 @@ It turns out we need those instructions for a different portion of the setup, bu
 - Install Docker for preliminary database and cache setup, [linked here](https://docs.docker.com/engine/install/ubuntu/)
 - Verify your docker is set up correctly: $ sudo docker run hello-world
 - Install docker compose (click on the Linux tab) [Link to Docker Documentation](https://docs.docker.com/compose/install/)
-- Turn on docker `sudo docker-compose up -d`
+- Turn on docker `sudo docker compose up -d`
 - Permission Denied Sad Path: `sudo usermod -aG docker $USER` (theoretically making it so you don’t have to use sudo, but let’s come back to this)
 Yarn bug: `wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
 https://github.com/StateVoicesNational/Spoke/blob/main/docker-compose.yml`

--- a/docs/HOWTO_DEVELOPMENT_LOCAL_SETUP.md
+++ b/docs/HOWTO_DEVELOPMENT_LOCAL_SETUP.md
@@ -78,12 +78,12 @@ Docker is optional, but can help with a consistent development environment using
 - Docker allows you to run apps in containers and can be installed [here with Docker's instructions](https://docs.docker.com/desktop/)
 - Docker Compose is the tool used to create and run docker configurations. If you installed Docker on Mac, you already have Docker Compose, if you're using Linux or Windows you can install Docker Compose [with these instructions](https://docs.docker.com/compose/install/)
 
-2. Make sure Docker is running on your machine and then build and run Spoke with `docker-compose up -d` to run redis and postgres in the background
-   - You can stop docker compose at any time with `docker-compose down`, and data will persist next time you run `docker-compose up`.
+2. Make sure Docker is running on your machine and then build and run Spoke with `docker compose up -d` to run redis and postgres in the background
+   - You can stop docker compose at any time with `docker compose down`, and data will persist next time you run `docker compose up`.
 
 3. Run `./dev-tools/create-test-database` to populate the test database
 
-4. When done testing, clean up resources with `docker-compose down`, or `docker-compose down -v` to **_completely destroy_** your Postgres database & Redis datastore volumes.
+4. When done testing, clean up resources with `docker compose down`, or `docker compose down -v` to **_completely destroy_** your Postgres database & Redis datastore volumes.
 
 ### Getting the app running
 

--- a/docs/HOWTO_DEVELOPMENT_LOCAL_SETUP.md
+++ b/docs/HOWTO_DEVELOPMENT_LOCAL_SETUP.md
@@ -80,6 +80,7 @@ Docker is optional, but can help with a consistent development environment using
 
 2. Make sure Docker is running on your machine and then build and run Spoke with `docker compose up -d` to run redis and postgres in the background
    - You can stop docker compose at any time with `docker compose down`, and data will persist next time you run `docker compose up`.
+   - **Note!** - `docker-compose` should in theory work with ComposeV2 as Docker considers it an alias for `docker compose`. [Read more about the migration of Compose](https://docs.docker.com/compose/migrate/#what-does-this-mean-for-my-projects-that-use-compose-v1)
 
 3. Run `./dev-tools/create-test-database` to populate the test database
 

--- a/docs/HOWTO_USE_POSTGRESQL.md
+++ b/docs/HOWTO_USE_POSTGRESQL.md
@@ -3,7 +3,7 @@
 To use Postgresql, follow these steps:
 
 1. Either install docker (recommended) or postgresql on your machine:
-   * If you installed docker run the database using: `docker-compose up`
+   * If you installed docker run the database using: `docker compose up`
    * If you installed postgres locally, create the spoke dev database: `psql -c "create database spokedev;"`
      * Then create a spoke user to connect to the database with `createuser -P spoke` with password "spoke" (to match the credentials in the .env.example file)
 1. In `.env` set `DB_TYPE=pg`. (Otherwise, you will use sqlite.)


### PR DESCRIPTION
# Fixes # (issue)
`docker-compose` has been deprecated in ComposeV2, and instead uses `docker compose`. 

## Description
Clarified documentation and changed `devTools`  `create-test-database` and `redis-cli` to reflect these changes. 

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/StateVoicesNational/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My PR is labeled [WIP] if it is in progress
