### PR TITLE
Better logs V2

### DIFF
--- a/__test__/extensions/contact-loaders/ngpvan/ngpvan.test.js
+++ b/__test__/extensions/contact-loaders/ngpvan/ngpvan.test.js
@@ -227,7 +227,6 @@ describe("ngpvan", () => {
           .reply(404);
 
         const savedListsResponse = await getClientChoiceData(organization);
-        console.log("HERE", JSON.parse(savedListsResponse.data))
         expect(JSON.parse(savedListsResponse.data)).toEqual({
           error: expect.stringMatching(
             /TESTING :: Error retrieving saved list metadata from VAN Error: Request id .+ failed; received status 404/

--- a/__test__/extensions/contact-loaders/ngpvan/ngpvan.test.js
+++ b/__test__/extensions/contact-loaders/ngpvan/ngpvan.test.js
@@ -43,6 +43,7 @@ describe("ngpvan", () => {
     let oldNgpVanWebhookUrl;
     let oldNgpVanAppName;
     let oldNgpVanApiKey;
+    let organization;
 
     beforeEach(async () => {
       oldNgpVanWebhookUrl = process.env.NGP_VAN_WEBHOOK_BASE_URL;
@@ -51,6 +52,7 @@ describe("ngpvan", () => {
       process.env.NGP_VAN_WEBHOOK_BASE_URL = "https://www.example.com";
       process.env.NGP_VAN_APP_NAME = "spoke";
       process.env.NGP_VAN_API_KEY = "topsecret";
+      organization = { name: "TESTING" }
     });
 
     afterEach(async () => {
@@ -61,7 +63,7 @@ describe("ngpvan", () => {
     });
 
     it("returns true when all required environment variables are present", async () => {
-      expect(await available()).toEqual({
+      expect(await available(organization)).toEqual({
         result: true,
         expiresSeconds: 86400
       });
@@ -73,7 +75,7 @@ describe("ngpvan", () => {
       });
 
       it("returns false", async () => {
-        expect(await available()).toEqual({
+        expect(await available(organization)).toEqual({
           result: false,
           expiresSeconds: 86400
         });

--- a/__test__/extensions/contact-loaders/ngpvan/ngpvan.test.js
+++ b/__test__/extensions/contact-loaders/ngpvan/ngpvan.test.js
@@ -88,6 +88,7 @@ describe("ngpvan", () => {
     let oldNgpVanCacheTtl;
     let oldNgpVanApiBaseUrl;
     let listItems;
+    let organization;
 
     beforeEach(async () => {
       oldMaximumListSize = process.env.NGP_VAN_MAXIMUM_LIST_SIZE;
@@ -100,6 +101,7 @@ describe("ngpvan", () => {
       process.env.NGP_VAN_API_KEY = "topsecret";
       process.env.NGP_VAN_CACHE_TTL = 30;
       process.env.NGP_VAN_API_BASE_URL = fakeNgpVanBaseApiUrl;
+      organization = {name: "TESTING"};
     });
 
     beforeEach(async () => {
@@ -222,11 +224,11 @@ describe("ngpvan", () => {
           )
           .reply(404);
 
-        const savedListsResponse = await getClientChoiceData();
-
+        const savedListsResponse = await getClientChoiceData(organization);
+        console.log("HERE", JSON.parse(savedListsResponse.data))
         expect(JSON.parse(savedListsResponse.data)).toEqual({
           error: expect.stringMatching(
-            /Error retrieving saved list metadata from VAN Error: Request id .+ failed; received status 404/
+            /TESTING :: Error retrieving saved list metadata from VAN Error: Request id .+ failed; received status 404/
           )
         });
         getSavedListsNock.done();

--- a/src/extensions/action-handlers/ngpvan-action.js
+++ b/src/extensions/action-handlers/ngpvan-action.js
@@ -379,7 +379,13 @@ export async function available(organization) {
   if (!result) {
     // eslint-disable-next-line no-console
     console.info(
-      "ngpvan-action unavailable. Missing one or more required environment variables"
+      `${organization.name} :: ngpvan-action unavailable. Status:
+        Needs either:\n
+        \tNGP_VAN_API_KEY: ${hasVanApiKey}\n
+        \tNGP_VAN_API_KEY_ENCRYPTED: ${hasVanApiKeyEncrypted}\n
+        Needs:\n
+        \tNGP_VAN_APP_NAME: ${hasVanAppName}
+      `
     );
   }
 

--- a/src/extensions/action-handlers/ngpvan-action.js
+++ b/src/extensions/action-handlers/ngpvan-action.js
@@ -370,10 +370,11 @@ export async function getClientChoiceData(organization) {
 // Besides this returning true, "test-action" will also need to be added to
 // process.env.ACTION_HANDLERS
 export async function available(organization) {
-  let result =
-    (hasConfig("NGP_VAN_API_KEY", organization) ||
-      hasConfig("NGP_VAN_API_KEY_ENCRYPTED", organization)) &&
-    hasConfig("NGP_VAN_APP_NAME", organization);
+  const hasVanApiKey = hasConfig("NGP_VAN_API_KEY", organization);
+  const hasVanApiKeyEncrypted = hasConfig("NGP_VAN_API_KEY_ENCRYPTED", organization);
+  const hasVanAppName = hasConfig("NGP_VAN_APP_NAME", organization);
+
+  let result = (hasVanApiKey || hasVanApiKeyEncrypted) && hasVanAppName;
 
   if (!result) {
     // eslint-disable-next-line no-console

--- a/src/extensions/contact-loaders/ngpvan/index.js
+++ b/src/extensions/contact-loaders/ngpvan/index.js
@@ -134,7 +134,6 @@ async function requestVanSavedLists(organization, skip) {
 
 export async function getClientChoiceData(organization, campaign, user) {
   let responseJson;
-  console.log("HERE", organization)
 
   try {
     responseJson = await requestVanSavedLists(organization);

--- a/src/extensions/contact-loaders/ngpvan/index.js
+++ b/src/extensions/contact-loaders/ngpvan/index.js
@@ -152,7 +152,7 @@ export async function getClientChoiceData(organization, campaign, user) {
       }
     }
   } catch (error) {
-    const message = `Error retrieving saved list metadata from VAN ${error}`;
+    const message = `${organization.name} :: Error retrieving saved list metadata from VAN :: ${error}`;
     // eslint-disable-next-line no-console
     console.log(message);
     return { data: `${JSON.stringify({ error: message })}` };

--- a/src/extensions/contact-loaders/ngpvan/index.js
+++ b/src/extensions/contact-loaders/ngpvan/index.js
@@ -134,6 +134,7 @@ async function requestVanSavedLists(organization, skip) {
 
 export async function getClientChoiceData(organization, campaign, user) {
   let responseJson;
+  console.log("HERE", organization)
 
   try {
     responseJson = await requestVanSavedLists(organization);
@@ -152,7 +153,7 @@ export async function getClientChoiceData(organization, campaign, user) {
       }
     }
   } catch (error) {
-    const message = `${organization.name} :: Error retrieving saved list metadata from VAN :: ${error}`;
+    const message = `${organization.name} :: Error retrieving saved list metadata from VAN ${error}`;
     // eslint-disable-next-line no-console
     console.log(message);
     return { data: `${JSON.stringify({ error: message })}` };

--- a/src/extensions/contact-loaders/ngpvan/index.js
+++ b/src/extensions/contact-loaders/ngpvan/index.js
@@ -65,7 +65,7 @@ export async function available(organization, user) {
 
   if (!result) {
     console.log(
-      "ngpvan contact loader unavailable. Missing one or more required environment variables."
+      `${organization} | ngpvan contact loader unavailable. Missing one or more required environment variables.`
     );
   }
 

--- a/src/extensions/contact-loaders/ngpvan/index.js
+++ b/src/extensions/contact-loaders/ngpvan/index.js
@@ -56,16 +56,23 @@ export async function available(organization, user) {
   // / If this is instantaneous, you can have it be 0 (i.e. always), but if it takes time
   // / to e.g. verify credentials or test server availability,
   // / then it's better to allow the result to be cached
+ 
+  const hasRawKey = hasConfig("NGP_VAN_API_KEY", organization);
+  const hasEncryptedKey = hasConfig("NGP_VAN_API_KEY_ENCRYPTED", organization)
+  const hasAppName = hasConfig("NGP_VAN_APP_NAME", organization);
+  const hasWebhook = hasConfig("NGP_VAN_WEBHOOK_BASE_URL", organization)
 
-  const result =
-    (hasConfig("NGP_VAN_API_KEY", organization) ||
-      hasConfig("NGP_VAN_API_KEY_ENCRYPTED", organization)) &&
-    hasConfig("NGP_VAN_APP_NAME", organization) &&
-    hasConfig("NGP_VAN_WEBHOOK_BASE_URL", organization);
+  const result = (hasRawKey || hasEncryptedKey) && hasAppName && hasWebhook;
 
   if (!result) {
     console.log(
-      `${organization} | ngpvan contact loader unavailable. Missing one or more required environment variables.`
+      `${organization.name} :: ngpvan contact loader unavailable. Status:\n
+      Needs one:\n
+      \tNGP_VAN_API_KEY: ${hasRawKey}\n
+      \tNGP_VAN_API_KEY_ENCRYPTED: ${hasEncryptedKey}\n
+      Needs both:\n
+      \tNGP_VAN_APP_NAME: ${hasAppName}\n
+      \tNGP_VAN_WEBHOOK_BASE_URL: ${hasWebhook}`
     );
   }
 

--- a/src/extensions/message-handlers/auto-optout/index.js
+++ b/src/extensions/message-handlers/auto-optout/index.js
@@ -43,26 +43,29 @@ export const available = organization => {
   }
 };
 
+// Part of the auto-opt out process. 
+// checks if message recieved states something like "stop", "quit", or "stop2quit"
 export const preMessageSave = async ({ messageToSave, organization }) => {
-  if (messageToSave.is_from_contact) {
+  if (messageToSave.is_from_contact) {  // checks if message is from the contact
     const config = Buffer.from(
       getConfig("AUTO_OPTOUT_REGEX_LIST_BASE64", organization) ||
         DEFAULT_AUTO_OPTOUT_REGEX_LIST_BASE64,
       "base64"
-    ).toString();
+    ).toString();  // converts DEFAULT_AUTO_OPTOUT_REGEX_LIST_BASE64 to regex
+                   // can be custom set in .env w/ AUTO_OPTOUT_REGEX_LIST_BASE64
     const regexList = JSON.parse(config || "[]");
-    const matches = regexList.filter(matcher => {
+    const matches = regexList.filter(matcher => { // checks if message contains opt-out langauge
       const re = new RegExp(matcher.regex, "i");
       return String(messageToSave.text).match(re);
     });
-    // console.log("auto-optout", matches, messageToSave.text, regexList);
-    if (matches.length) {
+    if (matches.length) {  // if more than one match, opt-out
       console.log(
         "auto-optout MATCH",
         `| campaign_contact_id: ${messageToSave.campaign_contact_id}`,
         `| reason: "${matches[0].reason}"`
       );
-      const reason = matches[0].reason || "auto_optout";
+      const reason = matches[0].reason || "auto_optout"; // with default opt-out regex,
+                                                         // reason will always be "stop"
       messageToSave.error_code = -133;
       return {
         contactUpdates: {

--- a/src/extensions/message-handlers/auto-optout/index.js
+++ b/src/extensions/message-handlers/auto-optout/index.js
@@ -59,8 +59,8 @@ export const preMessageSave = async ({ messageToSave, organization }) => {
     if (matches.length) {
       console.log(
         "auto-optout MATCH",
-        messageToSave.campaign_contact_id,
-        matches
+        `| campaign_contact_id: ${messageToSave.campaign_contact_id}`,
+        `| reason: "${matches[0].reason}"`
       );
       const reason = matches[0].reason || "auto_optout";
       messageToSave.error_code = -133;
@@ -154,3 +154,5 @@ export const postMessageSave = async ({
     }
   }
 };
+
+console.log("works w/ node")

--- a/src/extensions/message-handlers/auto-optout/index.js
+++ b/src/extensions/message-handlers/auto-optout/index.js
@@ -99,8 +99,8 @@ export const postMessageSave = async ({
   if (message.is_from_contact && handlerContext.autoOptOutReason) {
     console.log(
       "auto-optout.postMessageSave",
-      message.campaign_contact_id,
-      handlerContext.autoOptOutReason
+      `| campaign_contact_id: ${message.campaign_contact_id}`,
+      `| opt-out reason: ${handlerContext.autoOptOutReason}`
     );
     let contact = await cacheableData.campaignContact.load(
       message.campaign_contact_id,

--- a/src/extensions/message-handlers/auto-optout/index.js
+++ b/src/extensions/message-handlers/auto-optout/index.js
@@ -5,6 +5,13 @@ import { sendRawMessage } from "../../../server/api/mutations/sendMessage";
 const DEFAULT_AUTO_OPTOUT_REGEX_LIST_BASE64 =
   "W3sicmVnZXgiOiAiXlxccypzdG9wXFxifFxcYnJlbW92ZSBtZVxccyokfHJlbW92ZSBteSBuYW1lfFxcYnRha2UgbWUgb2ZmIHRoXFx3KyBsaXN0fFxcYmxvc2UgbXkgbnVtYmVyfGRvblxcVz90IGNvbnRhY3QgbWV8ZGVsZXRlIG15IG51bWJlcnxJIG9wdCBvdXR8c3RvcDJxdWl0fHN0b3BhbGx8Xlxccyp1bnN1YnNjcmliZVxccyokfF5cXHMqY2FuY2VsXFxzKiR8XlxccyplbmRcXHMqJHxeXFxzKnF1aXRcXHMqJCIsICJyZWFzb24iOiAic3RvcCJ9XQ==";
 
+// DEFAULT_AUTO_OPTOUT_REGEX_LIST_BASE64 converts to:
+
+// [{"regex": "^\\s*stop\\b|\\bremove me\\s*$|remove my name|\\btake me off th\\w+ list|
+// \\blose my number|don\\W?t contact me|delete my number|I opt out|stop2quit|stopall|
+// ^\\s*unsubscribe\\s*$|^\\s*cancel\\s*$|^\\s*end\\s*$|^\\s*quit\\s*$", 
+// "reason": "stop"}]
+
 export const serverAdministratorInstructions = () => {
   return {
     description: `

--- a/src/extensions/message-handlers/auto-optout/index.js
+++ b/src/extensions/message-handlers/auto-optout/index.js
@@ -164,5 +164,3 @@ export const postMessageSave = async ({
     }
   }
 };
-
-console.log("works w/ node")

--- a/src/extensions/service-vendors/twilio/index.js
+++ b/src/extensions/service-vendors/twilio/index.js
@@ -582,7 +582,21 @@ export async function handleIncomingMessage(message) {
     const finalMessage = await convertMessagePartsToMessage([
       pendingMessagePart
     ]);
-    console.log("Contact reply", finalMessage, pendingMessagePart);
+    console.log(
+      "Contact Reply\n", 
+      `\t| Message Status:      ${finalMessage.send_status}\n`,
+      `\t| From Contact? :      ${finalMessage.is_from_contact}\n`,
+      `\t| Contact Number:      ${finalMessage.contact_number}\n`, 
+      `\t| User Number:         ${finalMessage.user_number}\n`,
+      `\t| Text:                ${finalMessage.text.replace(/(\r\n|\n|\r)/gm, " ").substring(0, 45)}\n`,
+      `\t| Error Code:          ${finalMessage.error_code}\n`,
+      `\t| Service:             ${finalMessage.service || pendingMessagePart.service}\n`,
+      `\t| Media:               ${finalMessage.media.length === 0 ? "No media" : finalMessage.media}\n`,
+      `\t| Message Service SID: ${finalMessage.messageservice_sid}\n`,
+      `\t| Service ID:          ${finalMessage.service_id}\n`,
+      `\t| Parent ID:           ${pendingMessagePart.parent_id}\n`,
+      `\t| User ID:             ${finalMessage.user_id}`,
+    );
     if (finalMessage) {
       if (message.spokeCreatedAt) {
         finalMessage.created_at = message.spokeCreatedAt;

--- a/src/server/api/conversations.js
+++ b/src/server/api/conversations.js
@@ -188,9 +188,9 @@ export async function getConversations(
   }
   console.log(
     `Org Id: ${organizationId} :: getConversations sql -- \n`,
-    `\tawsContext: ${awsContext && awsContext.awsRequestId === undefined ? true : false}\n`,
-    `\tcursor: limit=${cursor.limit},  offset=${cursor.offset}\n`,
-    `\tassignmentsFilter: ${assignmentsFilter}\n`,
+    `\tawsContext: ${awsContext && awsContext.awsRequestId ? true : false}\n`,
+    `\tcursor: limit=${cursor.limit}, offset=${cursor.offset}\n`,
+    `\tassignmentsFilter: ${Object.keys(assignmentsFilter).length > 0 ? assignmentsFilter : "no filter"}\n`,
     `\toffsetLimitQuery: ${offsetLimitQuery.toString()}`
   );
 

--- a/src/server/api/conversations.js
+++ b/src/server/api/conversations.js
@@ -197,10 +197,10 @@ export async function getConversations(
   const ccIdRows = await offsetLimitQuery;
 
   console.log(
-    "getConversations contact ids",
-    awsContext && awsContext.awsRequestId,
-    Number(new Date()) - Number(starttime),
-    ccIdRows.length
+    `Org Id: ${organizationId} :: getConversations contact ids -- \n`,
+    `\tawsContext: ${awsContext && awsContext.awsRequestId === undefined ? true : false}\n`,
+    `\ttime: ${Number(new Date()) - Number(starttime)}ms\n`,
+    `\tccIdRows length: ${ccIdRows.length}`
   );
   const ccIds = ccIdRows.map(ccIdRow => {
     return ccIdRow.cc_id;

--- a/src/server/api/conversations.js
+++ b/src/server/api/conversations.js
@@ -320,8 +320,9 @@ export async function getConversations(
   /* Query #3 -- get the count of all conversations matching the criteria.
    * We need this to show total number of conversations to support paging */
   console.log(
-    "getConversations query3",
-    Number(new Date()) - Number(starttime)
+    "getConversations query3 total count + time for total completion of queries\n",
+    `\ttime: ${Number(new Date()) - Number(starttime)}ms\n`,
+    `\ttotal conversations: ${conversations.length}`
   );
   const conversationsCountQuery = getConversationsJoinsAndWhereClause(
     r.knexReadOnly,

--- a/src/server/api/conversations.js
+++ b/src/server/api/conversations.js
@@ -197,7 +197,7 @@ export async function getConversations(
   const ccIdRows = await offsetLimitQuery;
 
   console.log(
-    `Org Id: ${organizationId} :: getConversations contact ids -- \n`,
+    `Org Id: ${organizationId} :: getConversations query1 contact ids -- \n`,
     `\tawsContext: ${awsContext && awsContext.awsRequestId === undefined ? true : false}\n`,
     `\ttime: ${Number(new Date()) - Number(starttime)}ms\n`,
     `\tccIdRows length: ${ccIdRows.length}`

--- a/src/server/api/conversations.js
+++ b/src/server/api/conversations.js
@@ -254,10 +254,10 @@ export async function getConversations(
   query = query.orderBy("cc_id", "desc").orderBy("message.id");
   const conversationRows = await query;
   console.log(
-    "getConversations query2 result",
-    awsContext && awsContext.awsRequestId,
-    Number(new Date()) - Number(starttime),
-    conversationRows.length
+    `Org Id: ${organizationId} :: getConversations query2 conversations -- \n`,
+    `\tawsContext: ${awsContext && awsContext.awsRequestId === undefined ? true : false}\n`,
+    `\ttime: ${Number(new Date()) - Number(starttime)}ms\n`,
+    `\tconversationRows lenght: ${conversationRows.length}`
   );
   /* collapse the rows to produce an array of objects, with each object
    * containing the fields for one conversation, each having an array of

--- a/src/server/api/conversations.js
+++ b/src/server/api/conversations.js
@@ -187,11 +187,11 @@ export async function getConversations(
       .offset(cursor.offset);
   }
   console.log(
-    "getConversations sql",
-    awsContext && awsContext.awsRequestId,
-    cursor,
-    assignmentsFilter,
-    offsetLimitQuery.toString()
+    `Org Id: ${organizationId} :: getConversations sql -- \n`,
+    `\tawsContext: ${awsContext && awsContext.awsRequestId === undefined ? true : false}\n`,
+    `\tcursor: limit=${cursor.limit},  offset=${cursor.offset}\n`,
+    `\tassignmentsFilter: ${assignmentsFilter}\n`,
+    `\toffsetLimitQuery: ${offsetLimitQuery.toString()}`
   );
 
   const ccIdRows = await offsetLimitQuery;


### PR DESCRIPTION
# Fixes # (issue)
Creates clearer, common occurring logs.

## Description
Most information found in `console.logs` was jumbled, which benefitted from destructuring.
Others, like `getConversation` were confusing. Take a look at the old log:
```terminal
getConversations sql undefined { offset: 0, limit: 10 } {} select "campaign_contact"."id" as "cc_id" from "campaign_contact" inner join "campaign" on "campaign"."id" = "campaign_contact"."campaign_id" where "campaign"."organization_id" = '2' and "campaign"."is_archived" = false and "is_opted_out" = false order by "cc_id" desc limit 10
```
Here, `undefined`, dealt with awsContext, which is not apparent when looking at the log. Paired with `undefined` being followed by `sql`, caused some concern when not privy to what the `console.log` looks like. However, `getConversations sql` is a string within the log, and does not call any variable. 

Will now read like:
```terminal
Org ID: ## :: getConversations sql -- 
  awsContext: <>          // true or false rather, than undefined
  cursor: <>              // the {offset: #, limit: #}
  assignmentFilter: <>    // {}
  offsetLimitQuery: <>    // select... from... innerjoin... on...
```

Most changes to any `console.log` follows a similar destructuring. 

Additionally, most errors, like those commonly found when NGP VAN is not configured correctly, did not share what organization was causing the problem. This update focused on including org ids and other supporting information to help pinpoint any misconfiguration. This is most apparent in multi org situations. 

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ ] [My change is 300 lines of code or less](https://github.com/StateVoicesNational/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
