### PR TITLE
Dependabot Config File

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    target-branch: "stage-main-14.1"
+    schedule:
+      interval: "weekly"
+      dat: "monday"
+      time: "12:00"
+    rebase-strategy: auto
+    open-pull-requests-limit: 10
+    labels:
+      - "A-dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     target-branch: "stage-main-14.1"
     schedule:
       interval: "weekly"
-      dat: "monday"
+      day: "monday"
       time: "12:00"
     rebase-strategy: auto
     open-pull-requests-limit: 10


### PR DESCRIPTION
# Fixes # (issue)
Dependabot had no means of configuration. Added `dependabot.yaml` to `.github/`. I am guessing after the switch from MoveOn to StateVoices this was lost. 

## Description

| Option | Config | Context |
| --- | --- | --- |
| Ecosystem | `npm` | Checks `package.json` and any `lock` files against the `npm` registry. |
| Target Branch | `stage-main-14.1` | This sets up the target branch. Needs to be changed after every update |
| Interval | weekly | Self explanitory |
| Day | Monday | ^^  |
| Time | 12:00 UTC / 08:00 EST | ^^ |
| Rebase-strategy | auto | One of many strategies. `auto` checks for changes to target branch, and rebases as needed |
| PR Limit | 10 | Default is 5, didn't think 10 would be an issue |
| Labels | `A-dependecies` | Adds a label to the PR. May want to change this in the future after we go through the many labels |

Please see [dependabot config](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#configuration-options-for-dependabotyml) documentation.

Effectively, every Monday 8am EST time, we should see PR's open from `dependabot`. 


# Checklist:

- [ ] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ ] [My change is 300 lines of code or less](https://github.com/StateVoicesNational/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
