### PR TITLE
replaced soon to be deprecated set-output w/ patch

### DIFF
--- a/.github/workflows/jest-tests.yaml
+++ b/.github/workflows/jest-tests.yaml
@@ -30,7 +30,7 @@ jobs:
         node-version: 20
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
     - uses: actions/cache@v4
       id: yarn-cache
       with:
@@ -71,7 +71,7 @@ jobs:
         node-version: 20
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
     - uses: actions/cache@v4
       id: yarn-cache
       with:
@@ -112,7 +112,7 @@ jobs:
         node-version: 20
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
     - uses: actions/cache@v4
       id: yarn-cache
       with:
@@ -140,7 +140,7 @@ jobs:
 
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
     - uses: actions/cache@v4
       id: yarn-cache
       with:


### PR DESCRIPTION
# Fixes # (issue)
Fixes these warnings following these [docs](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
![image](https://github.com/user-attachments/assets/f05a5a8a-a8c1-41e2-9029-f4382a12a11a)

## Description

All changes went from:
```docker
run: echo "::set-output name=dir::$(yarn cache dir)"
```
To:
```docker
run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
```

# Checklist:

- [ ] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ ] [My change is 300 lines of code or less](https://github.com/StateVoicesNational/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
