### PR TITLE
Fix failing "Build / Build Docker image and and push to GHCR (push)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,6 +175,7 @@
     "uuid": "^9.0.0",
     "wait-for-expect": "^1.1.1",
     "webpack": "^5.92.1",
+    "webpack-cli": "^4.10.0",
     "webpack-manifest-plugin": "^5.0.0",
     "yup": "0.32.3"
   },
@@ -211,7 +212,6 @@
     "sqlite3": "^5.1.2",
     "supertest": "^6.3.4",
     "wait-on": "^2.1.0",
-    "webpack-cli": "^4.10.0",
     "webpack-dev-server": "3"
   },
   "lint-staged": {


### PR DESCRIPTION
# Fixes # (issue)
Fixes [#2344](https://github.com/StateVoicesNational/Spoke/issues/2344)
And potentially: [#2265](https://github.com/StateVoicesNational/Spoke/issues/2265)

## Description
Because the Docker image was set to production, `webpack-cli` (which was situated under dev dependencies) was never installed via `yarn`.

Moving `webpack-cli` fixes this problem

EDIT: See proof here: https://github.com/StateVoicesNational/Spoke/actions/runs/9979766158

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/StateVoicesNational/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My PR is labeled [WIP] if it is in progress
