### PR TITLE
fix for campaign sort bug

### DIFF
--- a/src/components/AdminCampaignList/CampaignTable.jsx
+++ b/src/components/AdminCampaignList/CampaignTable.jsx
@@ -307,8 +307,7 @@ export class CampaignTable extends React.Component {
   };
 
   render() {
-    const { campaigns, pageInfo } = this.props.data.organization.campaigns;
-    const { limit, offset, total } = pageInfo;
+    const { limit, offset, total } = this.props.data.organization.campaigns.pageInfo;
     const displayPage = Math.floor(offset / limit) + 1;
     let rowSizeList = [10, 20, 50, 100];
 
@@ -355,7 +354,7 @@ export class CampaignTable extends React.Component {
             break;
           case "rowSelectionChange":
             const ids = tableState.selectedRows.data.map(({ index }) => {
-              return campaigns[index].id;
+              return this.state.campaigns[index].id;
             });
             this.props.handleChecked(ids);
             break;
@@ -367,7 +366,7 @@ export class CampaignTable extends React.Component {
       }
     };
 
-    return campaigns.length === 0 ? (
+    return this.state.campaigns.length === 0 ? (
       <Empty title="No campaigns" icon={<SpeakerNotesIcon />} />
     ) : (
       <div>
@@ -377,7 +376,7 @@ export class CampaignTable extends React.Component {
           data={this.state.campaigns}
           columns={this.prepareTableColumns(
             this.props.data.organization,
-            campaigns
+            this.state.campaigns
           )}
           options={options}
         />

--- a/src/components/AdminCampaignList/CampaignTable.jsx
+++ b/src/components/AdminCampaignList/CampaignTable.jsx
@@ -120,7 +120,8 @@ export class CampaignTable extends React.Component {
           customBodyRender: (value, tableMeta) => {
             const campaign = campaigns.find(c => c.id === tableMeta.rowData[0]);
             return this.renderArchiveIcon(campaign);
-          }
+          },
+          sort: false
         },
         style: {
           width: "5em"

--- a/src/components/AdminCampaignList/CampaignTable.jsx
+++ b/src/components/AdminCampaignList/CampaignTable.jsx
@@ -39,7 +39,8 @@ export class CampaignTable extends React.Component {
   };
 
   state = {
-    dataTableKey: "initial"
+    dataTableKey: "initial",
+    campaigns: [...this.props.data.organization.campaigns.campaigns]
   };
 
   statusIsChanging = campaign => {
@@ -346,9 +347,9 @@ export class CampaignTable extends React.Component {
             break;
           case "sort":
             this.clearCampaignSelection();
-            campaigns.sort(this.sortFunc(tableState.sortOrder.name));
+            this.state.campaigns.sort(this.sortFunc(tableState.sortOrder.name));
             if (tableState.sortOrder.direction === "desc") {
-              campaigns.reverse();
+              this.state.campaigns.reverse()
             }
             break;
           case "rowSelectionChange":
@@ -372,7 +373,7 @@ export class CampaignTable extends React.Component {
         <br />
         <br />
         <MUIDataTable
-          data={campaigns}
+          data={this.state.campaigns}
           columns={this.prepareTableColumns(
             this.props.data.organization,
             campaigns

--- a/src/containers/AdminCampaignList.jsx
+++ b/src/containers/AdminCampaignList.jsx
@@ -19,7 +19,7 @@ import { dataTest } from "../lib/attributes";
 import loadData from "./hoc/load-data";
 import theme from "../styles/theme";
 import SortBy, {
-  DUE_DATE_DESC_SORT
+  ID_DESC_SORT
 } from "../components/AdminCampaignList/SortBy";
 import Search from "../components/Search";
 import CampaignTable from "../components/AdminCampaignList/CampaignTable";
@@ -38,7 +38,7 @@ const INITIAL_FILTER = {
   isArchived: false,
   searchString: ""
 };
-const INITIAL_SORT_BY = DUE_DATE_DESC_SORT.value;
+const INITIAL_SORT_BY = ID_DESC_SORT.value;
 
 export class AdminCampaignList extends React.Component {
   static propTypes = {


### PR DESCRIPTION
# Fixes # (issue)
Fix bug where when sorting campaign list, "white screen of death" would occur caused by attempting to write to a read only object.


## Description
set campaign data to `state`, allowing for manipulation
set the default sort to descending ID's

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/StateVoicesNational/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My PR is labeled [WIP] if it is in progress
