### PR TITLE
Grouped survey stats

### DIFF
--- a/src/components/AssignmentTexter/Controls.jsx
+++ b/src/components/AssignmentTexter/Controls.jsx
@@ -825,8 +825,8 @@ export class AssignmentTexterContactControls extends React.Component {
       currentQuestionAnswered = questionResponses[currentInteractionStep.id];
       const dupeTester = {};
       const shortener = answerValue => {
-        // label is for one-word values or e.g. "Yes: ...."
-        const label = answerValue.match(/^(\w+)([^\s\w]|$)/);
+        // label is for one-word values or e.g. "Yes: ...." or "[Yes] ..."
+        const label = answerValue.match(/^\W?(\w+)([^\s\w]|$)/);
         return label ? label[1] : answerValue;
       };
       currentQuestionOptions = currentQuestion.answerOptions

--- a/src/components/CollapsibleCard.jsx
+++ b/src/components/CollapsibleCard.jsx
@@ -1,0 +1,75 @@
+import PropTypes from "prop-types";
+import React from "react";
+import Chart from "../components/Chart";
+
+import Card from "@material-ui/core/Card";
+import CardHeader from "@material-ui/core/CardHeader";
+import Collapse from "@material-ui/core/Collapse";
+
+import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import IconButton from "@material-ui/core/IconButton";
+
+import withMuiTheme from "../containers/hoc/withMuiTheme";
+import theme from "../styles/theme";
+
+
+export class CollapsibleCard extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      open: !props.startCollapsed
+    };
+  }
+
+  render() {
+    const { children, title, colorTheme, muiTheme } = this.props;
+    const { open } = this.state;
+    const cardHeaderStyle = {};
+
+    if (colorTheme === "warning") {
+      cardHeaderStyle.backgroundColor = muiTheme.palette.warning.light;
+      cardHeaderStyle.color = muiTheme.palette.warning.contrastText;
+    } else {
+      cardHeaderStyle.backgroundColor = muiTheme.palette.primary.main;
+      cardHeaderStyle.color = muiTheme.palette.primary.contrastText;
+    }
+
+    return (
+      <Card>
+        <CardHeader
+          title={title} 
+          style={cardHeaderStyle}
+          action={(
+            <IconButton>
+              <ExpandMoreIcon />
+            </IconButton>
+          )}
+          onClick={newExpandedState => {
+            console.log("click", newExpandedState);
+            this.setState({ open: !open });
+          }}
+        />
+        <Collapse
+          in={open}
+          unmountOnExit
+          style={{
+            margin: "20px"
+          }}
+        >
+          {children}
+        </Collapse>
+      </Card>
+    );
+  }
+}
+
+CollapsibleCard.propTypes = {
+  children: PropTypes.array,
+  title: PropTypes.string,
+  startCollapsed: PropTypes.bool,
+  colorTheme: PropTypes.string
+};
+
+const ThemedCollapsibleCard = withMuiTheme(CollapsibleCard);
+
+export default ThemedCollapsibleCard;

--- a/src/components/CollapsibleCard.jsx
+++ b/src/components/CollapsibleCard.jsx
@@ -45,7 +45,6 @@ export class CollapsibleCard extends React.Component {
             </IconButton>
           )}
           onClick={newExpandedState => {
-            console.log("click", newExpandedState);
             this.setState({ open: !open });
           }}
         />
@@ -64,7 +63,6 @@ export class CollapsibleCard extends React.Component {
 }
 
 CollapsibleCard.propTypes = {
-  children: PropTypes.array,
   title: PropTypes.string,
   startCollapsed: PropTypes.bool,
   colorTheme: PropTypes.string

--- a/src/containers/AdminCampaignStats.jsx
+++ b/src/containers/AdminCampaignStats.jsx
@@ -113,7 +113,7 @@ class AdminCampaignStats extends React.Component {
             <div className={css(styles.flexColumn)}>
               <Stat title="responses" count={count} />
             </div>
-            <div className={css(styles.flexColumn)}>
+            <div className={css(styles.flexColumn)} style={{maxWidth: "50%"}}>
               <div className={css(styles.rightAlign)}>
                 <Chart
                   data={options.map(answer => [


### PR DESCRIPTION
## Description

Requested by Jim N (I can't find his Github account) -- This supports two groups of pie chart reports for survey/questions.

1. If multiple *questions* have text surrounded by `[]`s that is the same, then those question's answers will be grouped together at the top with a title of "Grouped Questions with [question text]"
    * example: question 1 = [Will you signup?] w/ answers "Yes", "No" and "Not sure" with a Not sure response nagging again and then asking [Will you signup?] really? and then "Yes" "No", then those questions and their "Yes"s and "No"s will be grouped into a single question and the "Not sure" will be added in-tandem (this makes the pie-chart a bit of a lie, if one of the answers leads to follow-on answers)
2. Furthermore, and separately, if multiple *answers* have text surrounded by `[]`s that are the same, then those answers will be grouped all together.
    * example: Question 1 = "Will you sign up?" w/ answers [Yes] and [No] and a later question also has answers [Yes] and [No] (or just one of those), then all of those will be grouped into "Responses Grouped by Answers (with []'s)" -- and a single pie chart will have an aswer [Yes] that is all the answers with [Yes] in them combined.

Finally, button text will also work if you make it .e.g "[Yes] I like it" => "Yes" just like "Yes: I like it" would do so before.  This makes it easier for buttons across questions to map to the grouped answer values in (2).

I'd like feedback on this feature before adding documentation to make sure one or the other or both features are what's desired and that it can work.

# Checklist: 

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/StateVoicesNational/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress

![spoke_surveysgrouped](https://github.com/user-attachments/assets/c4a080e3-3058-4a92-98ca-df24c84837ce)