### PR TITLE
past-contacts fixed from query-string import

### DIFF
--- a/src/extensions/contact-loaders/past-contacts/index.js
+++ b/src/extensions/contact-loaders/past-contacts/index.js
@@ -1,7 +1,7 @@
 import { completeContactLoad, failedContactLoad } from "../../../workers/jobs";
 import { r, cacheableData } from "../../../server/models";
 import { getConfig, hasConfig } from "../../../server/api/lib/config";
-import queryString from "query-string";
+import queryString from "node:querystring";
 import { getConversationFiltersFromQuery } from "../../../lib";
 import { getConversations } from "../../../server/api/conversations";
 import { getTags } from "../../../server/api/tag";


### PR DESCRIPTION
# Fixes past-contacts campaign loader

## Description

Past contacts is a useful extension that seems to have bit-rotted (maybe after node-upgrade)

# Checklist:

- [ ] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ ] [My change is 300 lines of code or less](https://github.com/StateVoicesNational/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
