### PR TITLE
update phone number button names

### DIFF
--- a/src/containers/AdminPhoneNumberInventory.js
+++ b/src/containers/AdminPhoneNumberInventory.js
@@ -407,7 +407,7 @@ class AdminPhoneNumberInventory extends React.Component {
 
           {this.props.params.ownerPerms ? (
             <Button
-              {...dataTest("buyPhoneNumbers")}
+              {...dataTest("getShortcodes")}
               color="primary"
               variant="contained"
               type="button"


### PR DESCRIPTION
# Fixes # (issue)
Fixes button names in the phone number inventory page to disambiguate the Buy Phone Numbers button from the Get Shortcodes button. 

## Description

The issue was that the buttons were named the same thing, causing the tests to fail. The button names have since been updated to resolve this issue.  


# Checklist:

- [ x] I have manually tested my changes on desktop and mobile
- [ x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ x] [My change is 300 lines of code or less](https://github.com/StateVoicesNational/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [ x] I have made any necessary changes to the documentation
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] My PR is labeled [WIP] if it is in progress
