### PR TITLE
Add button on Settings Page to clear entire Redis cache

### DIFF
--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -402,6 +402,7 @@ const rootSchema = gql`
     deletePhoneNumbers(organizationId: ID!, areaCode: String!): JobRequest
     releaseCampaignNumbers(campaignId: ID!): Campaign!
     clearCachedOrgAndExtensionCaches(organizationId: String!): String
+    clearEntireRedisCache(adminPerms: Boolean): String
   }
 
   schema {

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -402,7 +402,7 @@ const rootSchema = gql`
     deletePhoneNumbers(organizationId: ID!, areaCode: String!): JobRequest
     releaseCampaignNumbers(campaignId: ID!): Campaign!
     clearCachedOrgAndExtensionCaches(organizationId: String!): String
-    clearEntireRedisCache(adminPerms: Boolean): String
+    clearEntireRedisCache(adminPerms: Boolean!): String
   }
 
   schema {

--- a/src/containers/Settings/index.jsx
+++ b/src/containers/Settings/index.jsx
@@ -30,6 +30,8 @@ import { getServiceVendorComponent } from "../../extensions/service-vendors/comp
 import { getServiceManagerComponent } from "../../extensions/service-managers/components";
 import GSTextField from "../../components/forms/GSTextField";
 import ThemeEditor from "./themeEditor";
+import ListItem from "@material-ui/core/ListItem";
+import List from "@material-ui/core/List";
 
 const styles = StyleSheet.create({
   section: {
@@ -51,6 +53,7 @@ const styles = StyleSheet.create({
 });
 
 const formatTextingHours = hour => moment(hour, "H").format("h a");
+
 class Settings extends React.Component {
   state = {
     formIsSubmitting: false
@@ -81,9 +84,9 @@ class Settings extends React.Component {
   }
 
   handleSubmitTextingHoursForm = async ({
-    textingHoursStart,
-    textingHoursEnd
-  }) => {
+                                          textingHoursStart,
+                                          textingHoursEnd
+                                        }) => {
     await this.props.mutations.updateTextingHours(
       textingHoursStart,
       textingHoursEnd
@@ -199,8 +202,8 @@ class Settings extends React.Component {
                       sm.fullyConfigured === true
                         ? this.props.muiTheme.palette.success.main
                         : sm.fullyConfigured === false
-                        ? this.props.muiTheme.palette.warning.main
-                        : this.props.muiTheme.palette.grey[300]
+                          ? this.props.muiTheme.palette.warning.main
+                          : this.props.muiTheme.palette.grey[300]
                   }}
                 />
                 <CardContent>
@@ -474,16 +477,32 @@ class Settings extends React.Component {
                 <p>
                   Only take actions here if you know what you&rsquo;re doing
                 </p>
-                <Button
-                  color="secondary"
-                  variant="outlined"
-                  style={this.inlineStyles.dialogButton}
-                  onClick={
-                    this.props.mutations.clearCachedOrgAndExtensionCaches
-                  }
-                >
-                  Clear Cached Organization And Extension Caches
-                </Button>
+                <List>
+                  <ListItem>
+                    <Button
+                      color="secondary"
+                      variant="outlined"
+                      style={this.inlineStyles.dialogButton}
+                      onClick={
+                        this.props.mutations.clearCachedOrgAndExtensionCaches
+                      }
+                    >
+                      Clear Cached Organization And Extension Caches
+                    </Button>
+                  </ListItem>
+                  <ListItem>
+                    <Button
+                      color="secondary"
+                      variant="outlined"
+                      style={this.inlineStyles.dialogButton}
+                      onClick={
+                        this.props.mutations.clearEntireRedisCache
+                      }
+                    >
+                      Clear Entire Redis Cache
+                    </Button>
+                  </ListItem>
+                </List>
               </CardContent>
             </Collapse>
           </Card>
@@ -698,6 +717,19 @@ const mutations = {
       }
     };
   },
+  clearEntireRedisCache: ownProps => () => {
+    console.log('op prams', ownProps.params, ownProps.params.adminPerms)
+    return ({
+      mutation: gql`
+      mutation clearEntireRedisCache($adminPerms: Boolean!) {
+        clearEntireRedisCache(adminPerms: $adminPerms)
+      }
+    `,
+      variables: {
+        adminPerms:  ownProps.params.adminPerms
+      }
+    });
+  },
   clearCachedOrgAndExtensionCaches: ownProps => () => ({
     mutation: gql`
       mutation clearCachedOrgAndExtensionCaches($organizationId: String!) {
@@ -711,7 +743,7 @@ const mutations = {
 };
 
 const EnhancedSettings = withSetTheme(
-  loadData({ queries, mutations})(Settings)
+  loadData({ queries, mutations })(Settings)
 );
 
 export default EnhancedSettings;

--- a/src/containers/Settings/index.jsx
+++ b/src/containers/Settings/index.jsx
@@ -84,9 +84,9 @@ class Settings extends React.Component {
   }
 
   handleSubmitTextingHoursForm = async ({
-                                          textingHoursStart,
-                                          textingHoursEnd
-                                        }) => {
+    textingHoursStart,
+    textingHoursEnd
+  }) => {
     await this.props.mutations.updateTextingHours(
       textingHoursStart,
       textingHoursEnd
@@ -202,8 +202,8 @@ class Settings extends React.Component {
                       sm.fullyConfigured === true
                         ? this.props.muiTheme.palette.success.main
                         : sm.fullyConfigured === false
-                          ? this.props.muiTheme.palette.warning.main
-                          : this.props.muiTheme.palette.grey[300]
+                        ? this.props.muiTheme.palette.warning.main
+                        : this.props.muiTheme.palette.grey[300]
                   }}
                 />
                 <CardContent>
@@ -743,7 +743,7 @@ const mutations = {
 };
 
 const EnhancedSettings = withSetTheme(
-  loadData({ queries, mutations })(Settings)
+  loadData({ queries, mutations})(Settings)
 );
 
 export default EnhancedSettings;

--- a/src/containers/Settings/index.jsx
+++ b/src/containers/Settings/index.jsx
@@ -718,7 +718,6 @@ const mutations = {
     };
   },
   clearEntireRedisCache: ownProps => () => {
-    console.log('op prams', ownProps.params, ownProps.params.adminPerms)
     return ({
       mutation: gql`
       mutation clearEntireRedisCache($adminPerms: Boolean!) {

--- a/src/containers/Settings/index.jsx
+++ b/src/containers/Settings/index.jsx
@@ -725,7 +725,7 @@ const mutations = {
       }
     `,
       variables: {
-        adminPerms:  ownProps.params.adminPerms
+        adminPerms: ownProps.params.adminPerms
       }
     });
   },

--- a/src/server/api/mutations/clearEntireRedisCache.js
+++ b/src/server/api/mutations/clearEntireRedisCache.js
@@ -1,0 +1,20 @@
+import { r } from "../../models";
+
+export const clearEntireRedisCache = async (
+  _,
+  {adminPerms}
+)   => {
+  if (! adminPerms) {
+    return "You must have be an administrator to clear the Redis cache"
+  }
+  if (!r.redis) {
+    return "Redis not configured.";
+  }
+
+  try {
+    await r.redis.FLUSHDB()
+  } catch (caught) {
+    // eslint-disable-next-line no-console
+    console.error(`Error while clearing Redis cache. ${caught}`);
+  }
+}

--- a/src/server/api/mutations/clearEntireRedisCache.js
+++ b/src/server/api/mutations/clearEntireRedisCache.js
@@ -17,4 +17,5 @@ export const clearEntireRedisCache = async (
     // eslint-disable-next-line no-console
     console.error(`Error while clearing Redis cache. ${caught}`);
   }
+  return "Cleared entire Redis cache";
 }

--- a/src/server/api/mutations/index.js
+++ b/src/server/api/mutations/index.js
@@ -12,6 +12,7 @@ export { updateContactCustomFields } from "./updateContactCustomFields";
 export { updateQuestionResponses } from "./updateQuestionResponses";
 export { releaseCampaignNumbers } from "./releaseCampaignNumbers";
 export { clearCachedOrgAndExtensionCaches } from "./clearCachedOrgAndExtensionCaches";
+export { clearEntireRedisCache } from "./clearEntireRedisCache"
 export { updateFeedback } from "./updateFeedback";
 export { updateServiceManager } from "./updateServiceManager";
 export { updateServiceVendorConfig } from "./updateServiceVendorConfig";

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -70,6 +70,7 @@ import {
   updateQuestionResponses,
   releaseCampaignNumbers,
   clearCachedOrgAndExtensionCaches,
+  clearEntireRedisCache,
   updateFeedback,
   updateServiceManager,
   updateServiceVendorConfig
@@ -490,6 +491,7 @@ const rootMutations = {
     startCampaign,
     releaseCampaignNumbers,
     clearCachedOrgAndExtensionCaches,
+    clearEntireRedisCache,
     updateServiceManager,
     updateServiceVendorConfig,
     userAgreeTerms: async (_, { userId }, { user }) => {


### PR DESCRIPTION
# Fixes # (issue)
Feature Request: UI to clear Redis cache 
https://github.com/StateVoicesNational/Spoke/issues/2276

## Description
Adds a second button below the "Clear Organization Cache" that completely wipes out the Redis Cache.
This functionality is limited to those who have admin permissions.  
Let me know if either the permissions or the erasure of cache values should be further limited.


# Checklist:

- [ ] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ ] [My change is 300 lines of code or less](https://github.com/StateVoicesNational/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
