### PR TITLE
Fix type error when saving or deleting canned responses with tags

### DIFF
--- a/src/components/CampaignCannedResponseForm.jsx
+++ b/src/components/CampaignCannedResponseForm.jsx
@@ -186,14 +186,18 @@ export default class CannedResponseForm extends React.Component {
             fullWidth
             ref={this.autocompleteInput}
             options={
-              tags && tags.filter(t => this.state.tagIds.indexOf(t.id) === -1)
+              tags &&
+              tags.filter(t => this.state.tagIds.indexOf(parseInt(t.id)) === -1)
             }
             getOptionLabel={option => option.name}
             value={
-              tags && tags.filter(t => this.state.tagIds.indexOf(t.id) > -1)
+              tags &&
+              tags.filter(t => this.state.tagIds.indexOf(parseInt(t.id)) > -1)
             }
             onChange={(event, selectedTags) => {
-              this.setState({ tagIds: selectedTags.map(tag => tag.id) });
+              this.setState({
+                tagIds: selectedTags.map(tag => parseInt(tag.id))
+              });
             }}
             renderInput={params => {
               return <TextField {...params} label="Tags" />;

--- a/src/components/CampaignCannedResponsesForm.jsx
+++ b/src/components/CampaignCannedResponsesForm.jsx
@@ -75,7 +75,7 @@ export class CampaignCannedResponsesForm extends React.Component {
         WebkitBoxOrient: "vertical",
         WebkitLineClamp: 2,
         overflow: "hidden",
-        height: 32,
+        minHeight: 32,
         width: "90%"
       },
       redText: {

--- a/src/components/TagChips.jsx
+++ b/src/components/TagChips.jsx
@@ -13,7 +13,7 @@ const styles = StyleSheet.create({
 const TagChips = ({ tags, tagIds, onRequestDelete, extraProps }) => (
   <div className={css(styles.tagChips)}>
     {tagIds.map((id, i) => {
-      const listedTag = tags.find(t => t.id === id);
+      const listedTag = tags.find(t => t.id == id);
       return (
         listedTag && (
           <TagChip

--- a/src/components/utils.jsx
+++ b/src/components/utils.jsx
@@ -40,3 +40,8 @@ export function deepCopy(obj) {
     return obj;
   }
 }
+
+// Convert an array of strings to an array of integers
+export function convertToInt(array) {
+  return array.map(str => parseInt(str));
+}


### PR DESCRIPTION
# Fixes # (issue)

## Description

Bug reported that canned responses are not saving:
<img width="569" alt="Screenshot 2024-09-11 at 8 49 20 PM" src="https://github.com/user-attachments/assets/b0afdbe8-1541-4bf1-8a0d-69f4da09801b">
This type error prevented users from creating, editing, uploading and deleting canned responses that contained tags.

Also updated the UI to show entire canned response text (text was cut off when a canned response also had an action handler):

### before
<img width="503" alt="Screenshot 2024-09-13 at 2 57 23 AM" src="https://github.com/user-attachments/assets/6231422b-3e6d-43b5-95da-8fe23263ebe5">

### after
<img width="504" alt="Screenshot 2024-09-13 at 2 54 51 AM" src="https://github.com/user-attachments/assets/bcf04176-8dd7-4f9c-bd30-aed869f5e9c9">


# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/StateVoicesNational/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
