### PR TITLE
Remove attempted reassignment of read-only object, nextProps

### DIFF
--- a/src/containers/TexterTodoList.jsx
+++ b/src/containers/TexterTodoList.jsx
@@ -136,7 +136,8 @@ class TexterTodoList extends React.Component {
         <Snackbar
           open={Boolean(this.state.notifications)}
           message={"Some campaigns have replies for you to respond to!"}
-          onClose={() => {
+          autoHideDuration={4000}
+	        onClose={() => {
             this.setState({ notifications: false });
           }}
         />

--- a/src/containers/TexterTodoList.jsx
+++ b/src/containers/TexterTodoList.jsx
@@ -38,7 +38,6 @@ class TexterTodoList extends React.Component {
       this.props.notifications.stopPolling();
       this.props.notifications.startPolling(notificationPollDelay);
       // move the result to state
-      nextProps.notifications.user.notifications = [];
       // FUTURE: maybe append for a set of assignmentIds to display them
       nextState.notifications = notifications;
     }


### PR DESCRIPTION
# Fixes # (issue)

## Description
We noticed that each time a text response was received while on the texter view page (.../app/[org-id]/todos), the page would crash (white screen + error in the console). This was caused by an attempt to clear the user.notifications property of nextProps. nextProps however is read only and cannot be updated in this way. Removal of this line allows the notification pop up to display, however it does not disappear until the user clicks on respond or any other action that navigates away from the page.

<img width="928" alt="Screenshot 2024-09-20 at 12 20 32 PM" src="https://github.com/user-attachments/assets/7e714ead-0a2e-4b55-b76b-23c600203de5">

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/StateVoicesNational/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
