### PR TITLE
Fix getAsync + delAsync redis errors

### DIFF
--- a/src/server/models/cacheable_queries/opt-out-message.js
+++ b/src/server/models/cacheable_queries/opt-out-message.js
@@ -6,7 +6,7 @@ const cacheKey = (orgId, state) =>
 const optOutMessageCache = {
   clearQuery: async ({ organizationId, state }) => {
     if (r.redis) {
-      await r.redis.delAsync(cacheKey(organizationId, state));
+      await r.redis.del(cacheKey(organizationId, state));
     }
   },
   query: async ({ organizationId, state }) => {
@@ -21,7 +21,7 @@ const optOutMessageCache = {
     }
     if (r.redis) {
       const key = cacheKey(organizationId, state);
-      let message = await r.redis.getAsync(key);
+      let message = await r.redis.get(key);
 
       if (message !== null) {
         return message;

--- a/src/server/models/cacheable_queries/zip.js
+++ b/src/server/models/cacheable_queries/zip.js
@@ -20,7 +20,7 @@ const cacheKey = zip => `${process.env.CACHE_PREFIX || ""}state-of-${zip}`;
 const zipStateCache = {
   clearQuery: async ({ zip }) => {
     if (r.redis) {
-      await r.redis.delAsync(cacheKey(zip));
+      await r.redis.del(cacheKey(zip));
     }
   },
   query: async ({ zip }) => {
@@ -41,7 +41,7 @@ const zipStateCache = {
 
     if (r.redis) {
       const key = cacheKey(zip);
-      let state = await r.redis.getAsync(key);
+      let state = await r.redis.get(key);
 
       if (state !== null) {
         return state;


### PR DESCRIPTION
# Fixes # (issue)

## Description
During the Node 20 update, redis was also updated and getAsync() + delAsync() functions were deprecated. In Spoke v14.1, we merged in older code that still contained these functions. This branch cleans them up and prevents errors like below:
<img width="337" alt="Screenshot 2024-09-30 at 1 39 05 PM" src="https://github.com/user-attachments/assets/268686c0-7ae2-4d75-a740-456dc9eef480">

# Checklist:

- [ ] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ ] [My change is 300 lines of code or less](https://github.com/StateVoicesNational/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
