### PR TITLE
Allow users to enter 0 hours for instant reassignment

### DIFF
--- a/src/components/CampaignDynamicAssignmentForm.jsx
+++ b/src/components/CampaignDynamicAssignmentForm.jsx
@@ -2,7 +2,7 @@ import type from "prop-types";
 import React from "react";
 import GSForm from "../components/forms/GSForm";
 import GSSubmitButton from "../components/forms/GSSubmitButton";
-import GSIntegerField from "../components/forms/GSIntegerField"
+import GSIntegerField from "../components/forms/GSIntegerField";
 import GSTextField from "../components/forms/GSTextField";
 import * as yup from "yup";
 import Form from "react-formal";
@@ -54,7 +54,11 @@ class CampaignDynamicAssignmentForm extends React.Component {
 
   render() {
     const { joinToken, campaignId, organization } = this.props;
-    const { useDynamicAssignment, batchPolicies, useDynamicReplies } = this.state;
+    const {
+      useDynamicAssignment,
+      batchPolicies,
+      useDynamicReplies
+    } = this.state;
     const unselectedPolicies = organization.batchPolicies
       .filter(p => !batchPolicies.find(cur => cur === p))
       .map(p => ({ id: p, name: p }));
@@ -74,7 +78,7 @@ class CampaignDynamicAssignmentForm extends React.Component {
           label="Allow texters with a link to join and start texting when the campaign is started?"
           labelPlacement="start"
         />
-        <br/>
+        <br />
         <GSForm
           schema={this.formSchema}
           value={this.state}
@@ -126,8 +130,8 @@ class CampaignDynamicAssignmentForm extends React.Component {
               as={GSIntegerField}
               fullWidth
               name="responseWindow"
-              type="number"
               label="Expected Response Window (hours)"
+              inputProps={{ min: 0 }}
             />
             <p style={{ paddingLeft: "8px" }}>
               How long (in hours) before we should consider reassignment without
@@ -136,51 +140,49 @@ class CampaignDynamicAssignmentForm extends React.Component {
               hours for slower campaigns or 2 hours or less for GOTV campaigns.
             </p>
             <FormControlLabel
-          control={
-            <Switch
-              color="primary"
-              checked={useDynamicReplies || false}
-              onChange={(toggler, val) => {
-                console.log(toggler, val);
-                this.toggleChange("useDynamicReplies", val);
-              }}
+              control={
+                <Switch
+                  color="primary"
+                  checked={useDynamicReplies || false}
+                  onChange={(toggler, val) => {
+                    console.log(toggler, val);
+                    this.toggleChange("useDynamicReplies", val);
+                  }}
+                />
+              }
+              label="Allow texters with a link to dynamically get assigned replies?"
+              labelPlacement="start"
             />
-          }
-          label="Allow texters with a link to dynamically get assigned replies?"
-          labelPlacement="start"
-        />
 
-          {!useDynamicReplies ? null : (
-            <div>
-              <ul>
-                <li>
-                  {joinToken ? (
-                    <OrganizationReassignLink
-                      joinToken={joinToken}
-                      campaignId={campaignId}
-                    />
-                  ) : (
-                    "Please save the campaign and reload the page to get the reply link to share with texters."
-                  )}
-                </li>
-                <li>
-                  You can turn off dynamic assignment after starting a campaign
-                  to disallow more new texters to receive replies.
-                </li>
-              </ul>
+            {!useDynamicReplies ? null : (
+              <div>
+                <ul>
+                  <li>
+                    {joinToken ? (
+                      <OrganizationReassignLink
+                        joinToken={joinToken}
+                        campaignId={campaignId}
+                      />
+                    ) : (
+                      "Please save the campaign and reload the page to get the reply link to share with texters."
+                    )}
+                  </li>
+                  <li>
+                    You can turn off dynamic assignment after starting a
+                    campaign to disallow more new texters to receive replies.
+                  </li>
+                </ul>
 
-              <Form.Field
-                as={GSTextField}
-                fullWidth
-                name="replyBatchSize"
-                type="number"
-                label="How large should a batch of replies be?"
-                initialValue={200}
-              />  
-            </div>
-          )
-
-          }
+                <Form.Field
+                  as={GSTextField}
+                  fullWidth
+                  name="replyBatchSize"
+                  type="number"
+                  label="How large should a batch of replies be?"
+                  initialValue={200}
+                />
+              </div>
+            )}
             {organization.batchPolicies.length > 1 ? (
               <div>
                 <h3>Batch Strategy</h3>

--- a/src/components/forms/GSIntegerField.jsx
+++ b/src/components/forms/GSIntegerField.jsx
@@ -72,7 +72,7 @@ export default class GSIntegerField extends GSFormField {
       style
     };
     // can't be undefined or react throw uncontroled component error
-    if (!textFieldProps.value) {
+    if (textFieldProps.value !== 0 && !textFieldProps.value) {
       textFieldProps.value = "";
     }
     textFieldProps.style = Object.assign(
@@ -96,7 +96,7 @@ export default class GSIntegerField extends GSFormField {
         onChange={event => {
           onChange(Number(event.target.value));
         }}
-        type="number"
+        type="Number"
       />
     );
   }

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -352,7 +352,7 @@ export const resolvers = {
       const features = getFeatures(campaign);
       return features.USE_DYNAMIC_REPLIES ? features.USE_DYNAMIC_REPLIES : false;
     },
-    responseWindow: campaign => campaign.response_window || 48,
+    responseWindow: campaign => campaign.response_window != null ? campaign.response_window : 48,
     organization: async (campaign, _, { loaders }) =>
       campaign.organization ||
       loaders.organization.load(campaign.organization_id),

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -898,8 +898,9 @@ const rootMutations = {
           campaign.batch_size ||
           Number(getConfig("DEFAULT_BATCHSIZE", organization) || 300),
         response_window:
-          campaign.response_window ||
-          Number(getConfig("DEFAULT_RESPONSEWINDOW", organization) || 48),
+          campaign.response_window != null
+            ? campaign.response_window
+            : Number(getConfig("DEFAULT_RESPONSEWINDOW", organization) || 48),
         is_started: false,
         is_archived: false,
         join_token: uuidv4()


### PR DESCRIPTION
# Fixes # (issue)

## Description

Issue
- dynamic assignments do not support a 0 hour response window
- when 0 is entered in the input, the value disappears:
https://github.com/user-attachments/assets/f90a7a37-59f3-4659-847d-d980a866ea21

This branch fixes the UX and adds support for a 0 hour response window


# Checklist:

- [ ] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ ] [My change is 300 lines of code or less](https://github.com/StateVoicesNational/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
