### PR TITLE
Allow script import to add action handler to canned response

### DIFF
--- a/src/server/api/lib/import-script.js
+++ b/src/server/api/lib/import-script.js
@@ -355,10 +355,19 @@ const makeCannedResponsesList = cannedResponsesParagraphs => {
     ) {
       const textParagraph = cannedResponsesParagraphs.shift();
       if (textParagraph.isParagraphItalic) {
-        // Italic = tag.
+        // Italic = tag or action handler.
         const tagId = textParagraph.text.match(/^\d*\b/);
         if (tagId && !!tagId[0]) {
+          // Starting with a number = tag
           cannedResponse.tagIds.push(tagId[0]);
+        }
+        else {
+          // Statring with text = action handler
+          const handlerLabel = textParagraph.text.trim().toLowerCase();
+          const handler = actionHandlers[handlerLabel];
+          if (!handler) continue;
+          cannedResponse.answer_actions = handler.name;
+          cannedResponse.answer_actions_data = handler.data;
         }
       } else {
         // Regular text, add to response.


### PR DESCRIPTION
## Description

Found a stray branch I meant to create a PR for 2 years ago. This updates the Google Doc script importer to allow you to use action handlers on canned responses in addition to tags.

I also updated the template script linked in the HOTWTO file to reflect this: https://docs.google.com/document/d/1gFji2Vh_0svb4j7VUtmJZkqNhRWt3htp_bdGoWh6S6w/edit#heading=h.fo6nvxcomzft

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/StateVoicesNational/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
