### PR TITLE
Campaign Number Picker

### DIFF
--- a/src/extensions/service-managers/numpicker-campaign/index.js
+++ b/src/extensions/service-managers/numpicker-campaign/index.js
@@ -1,5 +1,4 @@
 import { getFeatures } from "../../../server/api/lib/config";
-import log from "../../../server/log";
 import { r, cacheableData } from "../../../server/models";
 import _ from "lodash";
 
@@ -22,13 +21,12 @@ export async function onMessageSend({
   campaign,
   serviceManagerData
 }) {
-  log.info({
-    category: name,
-    event: 'onMessageSend',
-    messageId: message.id,
-    userNumber: message.user_number,
+  console.log(
+    "numpicker-campaign.onMessageSend",
+    message.id,
+    message.user_number,
     serviceManagerData
-  });
+  );
   if (
     message.user_number ||
     (serviceManagerData && serviceManagerData.user_number)
@@ -39,22 +37,18 @@ export async function onMessageSend({
   }
   const campaignNumbers = getFeatures(campaign).campaignNumbers || [];
   const selectedPhone = _.sample(campaignNumbers);
-  log.info({
-    category: name,
-    event: 'selectedPhone',
-    selectedPhone
-  });
+  console.log("numpicker-campaign.onMessageSend selectedPhone", selectedPhone);
   // TODO: caching
   // TODO: something better than pure rotation -- maybe with caching we use metrics
   //   based on sad deliveryreports
   if (selectedPhone) {
     return { user_number: selectedPhone };
   } else {
-    log.warn({
-      category: name,
-      event: 'onMessageSend',
-      orgId: organization.id,
-    }, "None found");
+    console.log(
+      "numpicker-campaign.onMessageSend none found",
+      serviceName,
+      organization.id
+    );
   }
 }
 

--- a/src/extensions/service-managers/numpicker-campaign/index.js
+++ b/src/extensions/service-managers/numpicker-campaign/index.js
@@ -1,0 +1,116 @@
+import { getFeatures } from "../../../server/api/lib/config";
+import log from "../../../server/log";
+import { r, cacheableData } from "../../../server/models";
+import _ from "lodash";
+
+export const name = "numpicker-campaign";
+
+export const metadata = () => ({
+  displayName: "Campaign Number Picker",
+  description:
+    "Allows specific numbers to be chosen for a campaign. If there are multiple numbers, one is picked at random.",
+  canSpendMoney: false,
+  moneySpendingOperations: [],
+  supportsOrgConfig: false,
+  supportsCampaignConfig: true
+});
+
+export async function onMessageSend({
+  message,
+  contact,
+  organization,
+  campaign,
+  serviceManagerData
+}) {
+  log.info({
+    category: name,
+    event: 'onMessageSend',
+    messageId: message.id,
+    userNumber: message.user_number,
+    serviceManagerData
+  });
+  if (
+    message.user_number ||
+    (serviceManagerData && serviceManagerData.user_number)
+  ) {
+    // This is meant as a fallback -- if another serviceManager already
+    // chose a phone number then don't change anything
+    return;
+  }
+  const campaignNumbers = getFeatures(campaign).campaignNumbers || [];
+  const selectedPhone = _.sample(campaignNumbers);
+  log.info({
+    category: name,
+    event: 'selectedPhone',
+    selectedPhone
+  });
+  // TODO: caching
+  // TODO: something better than pure rotation -- maybe with caching we use metrics
+  //   based on sad deliveryreports
+  if (selectedPhone) {
+    return { user_number: selectedPhone };
+  } else {
+    log.warn({
+      category: name,
+      event: 'onMessageSend',
+      orgId: organization.id,
+    }, "None found");
+  }
+}
+
+async function _getAvailableNumbers(organization) {
+  const serviceName = cacheableData.organization.getMessageService(
+    organization
+  );
+  const availableNumbers = await r
+    .knex("owned_phone_number")
+    .where({ service: serviceName, organization_id: organization.id })
+    .whereNull("allocated_to_id")
+    .pluck("phone_number");
+
+  return availableNumbers;
+}
+
+export async function getCampaignData({
+  organization,
+  campaign,
+  user,
+  loaders,
+  fromCampaignStatsPage
+}) {
+  // MUST NOT RETURN SECRETS!
+  // called both from edit and stats contexts: editMode==true for edit page
+  if (fromCampaignStatsPage) {
+    return {};
+  } else {
+    const availableNumbers = await _getAvailableNumbers(organization);
+    const campaignNumbers = getFeatures(campaign).campaignNumbers;
+
+    return {
+      data: {
+        availableNumbers,
+        campaignNumbers
+      },
+      fullyConfigured: campaignNumbers > 0
+    };
+  }
+}
+
+export async function onCampaignUpdateSignal({
+  organization,
+  campaign,
+  updateData
+}) {
+  await cacheableData.campaign.setFeatures(campaign.id, {
+    campaignNumbers: updateData
+  });
+
+  return {
+    data: {
+      campaignNumbers: updateData,
+      availableNumbers: await _getAvailableNumbers(organization)
+    },
+    fullyConfigured: updateData.length > 0,
+    unArchiveable: false
+  };
+}

--- a/src/extensions/service-managers/numpicker-campaign/react-component.js
+++ b/src/extensions/service-managers/numpicker-campaign/react-component.js
@@ -1,0 +1,75 @@
+import PropTypes from "prop-types";
+import React from "react";
+import Form from "react-formal";
+import GSForm from "../../../components/forms/GSForm";
+import TextField from "@material-ui/core/TextField";
+import Autocomplete from "@material-ui/lab/Autocomplete";
+import GSSubmitButton from "../../../components/forms/GSSubmitButton";
+import { dataSourceItem } from "../../../components/utils";
+import { getDisplayPhoneNumber } from "../../../lib/phone-format";
+
+export class CampaignConfig extends React.Component {
+  constructor(props) {
+    super(props);
+    const selectedNumbers = this.props.serviceManagerInfo.data.campaignNumbers || [];
+    this.state = {
+      selectedNumbers: selectedNumbers.map(n =>
+        dataSourceItem(getDisplayPhoneNumber(n), n))
+    };
+  }
+
+  onNumberSelected = (event, selection) => {
+    this.setState({selectedNumbers: selection});
+  }
+
+  render() {
+    const selected = this.props.serviceManagerInfo.data.campaignNumbers || []
+      .map(n => getDisplayPhoneNumber(n))
+      .join(', ');
+
+    const numberOptions =
+      this.props.serviceManagerInfo &&
+      this.props.serviceManagerInfo.data &&
+      this.props.serviceManagerInfo.data.availableNumbers &&
+      this.props.serviceManagerInfo.data.availableNumbers.map(n =>
+        dataSourceItem(getDisplayPhoneNumber(n), n));
+    return (
+      <div>
+        Select the phone number(s) to use for this campaign.
+        {!this.props.campaign.isStarted || !selected ? (
+          <GSForm
+            onSubmit={() => {
+              this.props.onSubmit(this.state.selectedNumbers.map(n => n.rawValue));
+            }}
+          >
+            <Autocomplete
+              multiple
+              options={numberOptions}
+              onChange={this.onNumberSelected}
+              getOptionLabel={option => option.text || ""}
+              value={this.state.selectedNumbers || []}
+              renderInput={params => (
+                <TextField
+                  {...params}
+                  label="Select a number"
+                  placeholder="Search for a number"
+                />
+              )}
+            />
+            <Form.Submit as={GSSubmitButton} label="Save" />
+          </GSForm>
+        ) : (
+          <div>Using numbers: {selected}</div>
+        )}
+      </div>
+    );
+  }
+}
+
+CampaignConfig.propTypes = {
+  user: PropTypes.object,
+  campaign: PropTypes.object,
+  serviceManagerInfo: PropTypes.object,
+  saveLabel: PropTypes.string,
+  onSubmit: PropTypes.func
+};

--- a/src/lib/phone-format.js
+++ b/src/lib/phone-format.js
@@ -26,6 +26,7 @@ const parsePhoneNumber = (e164Number, country = "US") => {
 };
 
 export const getDisplayPhoneNumber = (e164Number, country = "US") => {
+  const phoneUtil = PhoneNumberUtil.getInstance();
   const parsed = parsePhoneNumber(e164Number, country);
   return phoneUtil.format(parsed, PhoneNumberFormat.NATIONAL);
 };


### PR DESCRIPTION
## Description

Adds a number picker service manager, which allows you to select specific numbers to use in the campaign configuration. 

![CleanShot 2024-10-04 at 15 13 49](https://github.com/user-attachments/assets/ea087c8e-cd69-4b84-abd0-d9559ccdbe99)

This serves the same basic purpose as the former `EXPERIMENTAL_CAMPAIGN_PHONE_NUMBERS` feature did before it was removed in version 11.0. The current `per-campaign-messageservices` service manager can also serve a similar purpose, except it's specific to Twilio.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/StateVoicesNational/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
