### PR TITLE
Fix Redis and readonly DB certificate issues

### DIFF
--- a/src/server/models/cacheable_queries/organization-contact.js
+++ b/src/server/models/cacheable_queries/organization-contact.js
@@ -27,7 +27,7 @@ const organizationContactCache = {
     if (r.redis && organizationContact) {
       await r.redis
         .MULTI()
-        .SET(cachekey, json.stringify(organizationcontact))
+        .SET(cacheKey, JSON.stringify(organizationContact))
         .EXPIRE(cacheKey, 43200) // 12 hours
         .exec();
     }


### PR DESCRIPTION
# Description

After upgrading to v14, our connections to the Redis cache and the readonly follower database started failing with errors for self-signed certificates.

This PR updates the readonly database connection code to match the main database connection, and uses the correct configuration syntax for newer versions of `node-redis`.

Also fixes an unrelated error that occurs when redis is enabled that originated from the node upgrade.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/StateVoicesNational/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My PR is labeled [WIP] if it is in progress
