### PR TITLE
Fix user edit with extra fields

### DIFF
--- a/src/containers/UserEdit.jsx
+++ b/src/containers/UserEdit.jsx
@@ -291,9 +291,12 @@ export class UserEditBase extends React.Component {
       router
     } = this.props;
     const onCancel = this.props.onCancel || (router && router.goBack);
-    const user = (this.state.editedUser && this.state.editedUser.user) || {};
+    let user = (this.state.editedUser && this.state.editedUser.user) || {};
     if (user && typeof user.extra === "string") {
-      user.extra = JSON.parse(user.extra);
+      user = {
+        ...user,
+        extra: JSON.parse(user.extra),
+      }
     }
     const org = this.state.currentOrg && this.state.currentOrg.organization;
     const formSchema = this.buildFormSchema(authType, org);


### PR DESCRIPTION
## Description

Starting with v14, if your organization has "extra" profile fields configured, attempting to edit a user results in a blank screen and an error in the javascript console: "Attempted to assign to readonly property"

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/StateVoicesNational/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My PR is labeled [WIP] if it is in progress
