### PR TITLE
Avoid error on opt-out

### DIFF
--- a/src/server/api/mutations/getOptOutMessage.js
+++ b/src/server/api/mutations/getOptOutMessage.js
@@ -1,3 +1,4 @@
+import { getConfig } from "../lib/config";
 import optOutMessageCache from "../../models/cacheable_queries/opt-out-message";
 import zipStateCache from "../../models/cacheable_queries/zip";
 
@@ -5,6 +6,9 @@ export const getOptOutMessage = async (
   _,
   { organizationId, zip, defaultMessage }
 ) => {
+  if (!getConfig("OPT_OUT_PER_STATE")) {
+    return defaultMessage;
+  }
   try {
     const queryResult = await optOutMessageCache.query({
       organizationId: organizationId,


### PR DESCRIPTION
## Description

With the per-state opt-out message feature introduced in #2333, an error gets logged on each opt-out if you don't have the Smarty API configured. These error are harmless since it returns the default opt-out message anyway, but still, they can be avoided.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/StateVoicesNational/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My PR is labeled [WIP] if it is in progress
