### PR TITLE
Fix UserInputError GraphQL errors

### DIFF
--- a/src/components/IncomingMessageFilter.jsx
+++ b/src/components/IncomingMessageFilter.jsx
@@ -412,7 +412,8 @@ class IncomingMessageFilter extends Component {
                   placeholder="Error code number"
                   label="Error codes"
                   value={this.state.errorCode}
-                  onChange={(_, errorCode) => {
+                  onChange={event => {
+                    const errorCode = event.target.value;
                     this.setState({ errorCode });
                   }}
                   onKeyPress={evt => {

--- a/src/containers/AdminIncomingMessageList.jsx
+++ b/src/containers/AdminIncomingMessageList.jsx
@@ -234,7 +234,7 @@ export class AdminIncomingMessageList extends Component {
   handleReassignAllMatchingRequested = async newTexterUserId => {
     await this.props.mutations.bulkReassignCampaignContacts(
       this.props.params.organizationId,
-      newTexterUserId,
+      newTexterUserId.toString(),
       this.state.campaignsFilter || {},
       this.state.assignmentsFilter || {},
       this.state.contactsFilter || {},

--- a/src/containers/AdminIncomingMessageList.jsx
+++ b/src/containers/AdminIncomingMessageList.jsx
@@ -185,7 +185,7 @@ export class AdminIncomingMessageList extends Component {
   handleErrorCodeChange = async errorCode => {
     const contactsFilter = {
       ...this.state.contactsFilter,
-      errorCode: errorCode ? errorCode.split(",") : null
+      errorCode: errorCode ? errorCode.split(",").map(Number) : null
     };
     await this.setState({
       contactsFilter,

--- a/src/containers/TexterTodo.jsx
+++ b/src/containers/TexterTodo.jsx
@@ -276,7 +276,7 @@ const queries = {
         ownProps.location.query.review === "1"
           ? {
               messageStatus,
-              errorCode: ["0"],
+              errorCode: [0],
               ...(ownProps.params.reviewContactId && {
                 contactId: ownProps.params.reviewContactId
               })

--- a/src/lib/conversations.js
+++ b/src/lib/conversations.js
@@ -97,7 +97,7 @@ export const getConversationFiltersFromQuery = (query, organizationTags) => {
     filters.contactsFilter.messageStatus = query.messageStatus;
   }
   if (query.errorCode) {
-    filters.contactsFilter.errorCode = query.errorCode.split(",");
+    filters.contactsFilter.errorCode = query.errorCode.split(",").map(Number);
   }
   if (query.tags) {
     if (/^[a-z]/.test(query.tags)) {

--- a/src/server/api/conversations.js
+++ b/src/server/api/conversations.js
@@ -483,7 +483,7 @@ export async function reassignConversations(
 
         returnCampaignIdAssignmentIds.push({
           campaignId,
-          assignmentId: assignmentId.toString()
+          assignmentId: assignmentId?.toString()
         });
       }
     }


### PR DESCRIPTION
## Description

If you try to use the bulk reassign button in the admin message review screen, you get a GraphQL `UserInputError` because `newTexterUserId` is an int instead of the expected string.

![CleanShot 2024-10-15 at 14 31 38](https://github.com/user-attachments/assets/43d6ed25-e685-43cd-98d8-033172ca9c81)

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/StateVoicesNational/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My PR is labeled [WIP] if it is in progress
