### PR TITLE
Heroku Plan Update

### DIFF
--- a/app.json
+++ b/app.json
@@ -183,7 +183,7 @@
     }
   },
   "addons": [
-    "heroku-postgresql:basic",
+    "heroku-postgresql:essential-0",
     {
       "plan": "heroku-redis:mini",
       "options": {


### PR DESCRIPTION
# Fixes # (issue)
#2484 

## Description
Change Heroku postgresql plan from `basic` to `essential-0`. `basic` was deprecated in May of 2024. Unsure of equivalency, but `essential-0` is the most basic postgresql plan Heroku has to offer. This `essential-0` plan is 4,000 tables, 1GB Disk Size, and 20 Conneciton limit Cost is 5$ a month max ($0.0007/hour).
Upgrading to `essential-1` increases disk size to 10GB for an additional 4$.

The two other services, mailgun and redis, are still okay (even though redis is running the `mini` plan).

Sources:
redis: https://elements.heroku.com/addons/heroku-redis
mailgun: https://devcenter.heroku.com/articles/mailgun
postgresql: https://elements.heroku.com/addons/heroku-postgresql