### PR TITLE
Remove unused variables causing /phone-numbers blank screen error for Admins

### DIFF
--- a/src/containers/AdminPhoneNumberInventory.js
+++ b/src/containers/AdminPhoneNumberInventory.js
@@ -263,9 +263,6 @@ class AdminPhoneNumberInventory extends React.Component {
   }
 
   renderBuyNumbersForm() {
-    const service = this.props.data.organization.serviceVendor;
-    const serviceName = service.name;
-    const serviceConfig = service.config || "{}";
     return (
       <GSForm
         schema={this.buyNumbersFormSchema()}

--- a/src/containers/AdminPhoneNumberInventory.js
+++ b/src/containers/AdminPhoneNumberInventory.js
@@ -48,6 +48,9 @@ const inlineStyles = {
   cancelButton: {
     marginTop: 15,
     marginRight: 5
+  },
+  deleteButton: {
+    marginTop: 15
   }
 };
 
@@ -417,8 +420,8 @@ class AdminPhoneNumberInventory extends React.Component {
             </Button>
             <Button
               variant="contained"
-              color="secondary"
-              variant="outlined"
+              color="primary"
+              style={inlineStyles.deleteButton}
               onClick={this.handleDeletePhoneNumbersSubmit}
             >
               Delete {this.state.deleteNumbersCount} Numbers


### PR DESCRIPTION
# Fixes # (issue)

## Description

Removes no longer used variables that causes a blank screen error on the /phone-numbers page for Admins users (does not occur for Owners). Also pulled in a styling fix from PR #2457

### before
![before](https://github.com/user-attachments/assets/0868efb7-9b8d-4679-96da-3ec614101625)

### after
<img width="491" alt="after" src="https://github.com/user-attachments/assets/02b72b87-4660-47c4-86e1-0c2b6467dd88">


# Checklist:

- [ ] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ ] [My change is 300 lines of code or less](https://github.com/StateVoicesNational/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
