### PR TITLE
(fix): Rm due date on copied campaigns

### DIFF
--- a/__test__/backend.test.js
+++ b/__test__/backend.test.js
@@ -639,9 +639,9 @@ describe("graphql test suite", () => {
           const parsedDate = new Date(copiedCampaign.due_by);
           expect(parsedDate).toEqual(campaign.due_by);
         } else if (isSqlite) {
-          expect(copiedCampaign.due_by.getTime()).toEqual(campaign.due_by);
+          expect(copiedCampaign.due_by.getTime()).toEqual(null);
         } else {
-          expect(copiedCampaign.due_by).toEqual(campaign.due_by);
+          expect(copiedCampaign.due_by).toEqual(null);
         }
 
         if (

--- a/__test__/backend.test.js
+++ b/__test__/backend.test.js
@@ -639,7 +639,7 @@ describe("graphql test suite", () => {
           const parsedDate = new Date(copiedCampaign.due_by);
           expect(parsedDate).toEqual(campaign.due_by);
         } else if (isSqlite) {
-          expect(copiedCampaign.due_by.getTime()).toEqual(null);
+          expect(copiedCampaign.due_by).toEqual(null);
         } else {
           expect(copiedCampaign.due_by).toEqual(null);
         }

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -882,7 +882,7 @@ const rootMutations = {
         creator_id: user.id,
         title: "COPY - " + campaign.title.replace(/\s*template\W*/i, ""),
         description: campaign.description,
-        due_by: campaign.due_by,
+        due_by: null,
         features: campaign.features,
         intro_html: campaign.intro_html,
         primary_color: campaign.primary_color,


### PR DESCRIPTION
# Fixes # ([2185](https://github.com/StateVoicesNational/Spoke/issues/2185))

## Description

Remove `due_by` for copied campaigns to avoid creating campaigns with due dates in the past.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/StateVoicesNational/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
